### PR TITLE
v2.0.0

### DIFF
--- a/ReflectionTools.Tests/Accessor_CallerParameters.cs
+++ b/ReflectionTools.Tests/Accessor_CallerParameters.cs
@@ -1,0 +1,348 @@
+﻿using DanielWillett.ReflectionTools.Tests.SampleObjects;
+
+namespace DanielWillett.ReflectionTools.Tests;
+
+[TestClass]
+[TestCategory("Accessor")]
+public class Accessor_CallerParameters
+{
+    private delegate void TestStaticMethodWithRefVTParameter(int value, ref int refValue);
+    [TestMethod]
+    public void TestBasicDelegateStaticRefVTParameter()
+    {
+        const string methodName = "TestMethodWithRefVTParameter";
+        const int value = 4;
+
+        using LogListener listener = new LogListener("Created basic delegate");
+
+        TestStaticMethodWithRefVTParameter caller = Accessor.GenerateStaticCaller<SampleStaticMembers, TestStaticMethodWithRefVTParameter>(methodName, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a basic delegate.");
+
+        int refValue = 0;
+        caller(value, ref refValue);
+
+        Assert.AreEqual(value, refValue);
+    }
+    private delegate void TestStaticMethodWithRefRTParameter(string value, ref string refValue);
+    [TestMethod]
+    public void TestBasicDelegateStaticRefRTParameter()
+    {
+        const string methodName = "TestMethodWithRefRTParameter";
+        const string value = "test";
+
+        using LogListener listener = new LogListener("Created basic delegate");
+
+        TestStaticMethodWithRefRTParameter caller = Accessor.GenerateStaticCaller<SampleStaticMembers, TestStaticMethodWithRefRTParameter>(methodName, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a basic delegate.");
+
+        string refValue = "not test";
+        caller(value, ref refValue);
+
+        Assert.AreEqual(value, refValue);
+    }
+    private delegate void TestInstanceMethodWithRefVTParameter(SampleClass instance, int value, ref int refValue);
+    [TestMethod]
+    public void TestDynamicMethodInstanceRefVTParameter()
+    {
+        const string methodName = "TestMethodWithRefVTParameter";
+        const int value = 4;
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        TestInstanceMethodWithRefVTParameter caller = Accessor.GenerateInstanceCaller<SampleClass, TestInstanceMethodWithRefVTParameter>(methodName, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        int refValue = 0;
+
+        caller(new SampleClass(), value, ref refValue);
+
+        Assert.AreEqual(value, refValue);
+    }
+    private delegate void TestInstanceMethodWithRefRTParameter(SampleClass instance, string value, ref string refValue);
+    [TestMethod]
+    public void TestDynamicMethodInstanceRefRTParameter()
+    {
+        const string methodName = "TestMethodWithRefRTParameter";
+        const string value = "test";
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        TestInstanceMethodWithRefRTParameter caller = Accessor.GenerateInstanceCaller<SampleClass, TestInstanceMethodWithRefRTParameter>(methodName, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        string refValue = "not test";
+
+        caller(new SampleClass(), value, ref refValue);
+
+        Assert.AreEqual(value, refValue);
+    }
+    private delegate void TestUnsafeInstanceMethodWithRefVTParameter(object instance, int value, ref int refValue);
+    [TestMethod]
+    public void TestUnsafeDelegateInstanceRefVTParameter()
+    {
+        const string methodName = "TestMethodWithRefVTParameter";
+        const int value = 4;
+
+        using LogListener listener = new LogListener("Created unsafely binded delegate");
+
+        TestUnsafeInstanceMethodWithRefVTParameter caller = Accessor.GenerateInstanceCaller<SampleClass, TestUnsafeInstanceMethodWithRefVTParameter>(methodName, allowUnsafeTypeBinding: true, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+#if NET6_0_OR_GREATER
+        Assert.IsFalse(listener.Result, "Method created with an unsafely binded delegate on .NET 6.0 or later.");
+#else
+        Assert.IsTrue(listener.Result, "Method was not created with a unsafely binded delegate.");
+#endif
+
+        int refValue = 0;
+
+        caller(new SampleClass(), value, ref refValue);
+
+        Assert.AreEqual(value, refValue);
+    }
+    private delegate void TestUnsafeInstanceMethodWithRefRTParameter(object instance, string value, ref string refValue);
+    [TestMethod]
+    public void TestUnsafeDelegateInstanceRefRTParameter()
+    {
+        const string methodName = "TestMethodWithRefRTParameter";
+
+        const string value = "test";
+
+        using LogListener listener = new LogListener("Created unsafely binded delegate");
+
+        TestUnsafeInstanceMethodWithRefRTParameter caller = Accessor.GenerateInstanceCaller<SampleClass, TestUnsafeInstanceMethodWithRefRTParameter>(methodName, allowUnsafeTypeBinding: true, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+#if NET6_0_OR_GREATER
+        Assert.IsFalse(listener.Result, "Method created with an unsafely binded delegate on .NET 6.0 or later.");
+#else
+        Assert.IsTrue(listener.Result, "Method was not created with a unsafely binded delegate.");
+#endif
+
+        string refValue = "not test";
+
+        caller(new SampleClass(), value, ref refValue);
+
+        Assert.AreEqual(value, refValue);
+
+    }
+    private delegate void TestStaticMethodWithOutVTParameter(int value, out int outValue);
+    [TestMethod]
+    public void TestBasicDelegateStaticOutVTParameter()
+    {
+        const string methodName = "TestMethodWithOutVTParameter";
+        const int value = 4;
+
+        using LogListener listener = new LogListener("Created basic delegate");
+
+        TestStaticMethodWithOutVTParameter caller = Accessor.GenerateStaticCaller<SampleStaticMembers, TestStaticMethodWithOutVTParameter>(methodName, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a basic delegate.");
+
+        caller(value, out int outValue);
+
+        Assert.AreEqual(value, outValue);
+    }
+    private delegate void TestStaticMethodWithOutRTParameter(string value, out string outValue);
+    [TestMethod]
+    public void TestBasicDelegateStaticOutRTParameter()
+    {
+        const string methodName = "TestMethodWithOutRTParameter";
+        const string value = "test";
+
+        using LogListener listener = new LogListener("Created basic delegate");
+
+        TestStaticMethodWithOutRTParameter caller = Accessor.GenerateStaticCaller<SampleStaticMembers, TestStaticMethodWithOutRTParameter>(methodName, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a basic delegate.");
+
+        caller(value, out string outValue);
+
+        Assert.AreEqual(value, outValue);
+    }
+    private delegate void TestInstanceMethodWithOutVTParameter(SampleClass instance, int value, out int outValue);
+    [TestMethod]
+    public void TestDynamicMethodInstanceOutVTParameter()
+    {
+        const string methodName = "TestMethodWithOutVTParameter";
+        const int value = 4;
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        TestInstanceMethodWithOutVTParameter caller = Accessor.GenerateInstanceCaller<SampleClass, TestInstanceMethodWithOutVTParameter>(methodName, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        caller(new SampleClass(), value, out int outValue);
+
+        Assert.AreEqual(value, outValue);
+    }
+    private delegate void TestInstanceMethodWithOutRTParameter(SampleClass instance, string value, out string outValue);
+    [TestMethod]
+    public void TestDynamicMethodInstanceOutRTParameter()
+    {
+        const string methodName = "TestMethodWithOutRTParameter";
+        const string value = "test";
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        TestInstanceMethodWithOutRTParameter caller = Accessor.GenerateInstanceCaller<SampleClass, TestInstanceMethodWithOutRTParameter>(methodName, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        caller(new SampleClass(), value, out string outValue);
+
+        Assert.AreEqual(value, outValue);
+    }
+    private delegate void TestUnsafeInstanceMethodWithOutVTParameter(object instance, int value, out int outValue);
+    [TestMethod]
+    public void TestUnsafeDelegateInstanceOutVTParameter()
+    {
+        const string methodName = "TestMethodWithOutVTParameter";
+        const int value = 4;
+
+        using LogListener listener = new LogListener("Created unsafely binded delegate");
+
+        TestUnsafeInstanceMethodWithOutVTParameter caller = Accessor.GenerateInstanceCaller<SampleClass, TestUnsafeInstanceMethodWithOutVTParameter>(methodName, allowUnsafeTypeBinding: true, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+#if NET6_0_OR_GREATER
+        Assert.IsFalse(listener.Result, "Method created with an unsafely binded delegate on .NET 6.0 or later.");
+#else
+        Assert.IsTrue(listener.Result, "Method was not created with a unsafely binded delegate.");
+#endif
+
+        caller(new SampleClass(), value, out int outValue);
+
+        Assert.AreEqual(value, outValue);
+    }
+    private delegate void TestUnsafeInstanceMethodWithOutRTParameter(object instance, string value, out string outValue);
+    [TestMethod]
+    public void TestUnsafeDelegateInstanceOutRTParameter()
+    {
+        const string methodName = "TestMethodWithOutRTParameter";
+        const string value = "test";
+
+        using LogListener listener = new LogListener("Created unsafely binded delegate");
+
+        TestUnsafeInstanceMethodWithOutRTParameter caller = Accessor.GenerateInstanceCaller<SampleClass, TestUnsafeInstanceMethodWithOutRTParameter>(methodName, allowUnsafeTypeBinding: true, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+#if NET6_0_OR_GREATER
+        Assert.IsFalse(listener.Result, "Method created with an unsafely binded delegate on .NET 6.0 or later.");
+#else
+        Assert.IsTrue(listener.Result, "Method was not created with a unsafely binded delegate.");
+#endif
+
+        caller(new SampleClass(), value, out string outValue);
+
+        Assert.AreEqual(value, outValue);
+    }
+    private delegate void TestStaticMethodWithInVTParameter(int value, in int inValue);
+    [TestMethod]
+    public void TestBasicDelegateStaticInVTParameter()
+    {
+        const string methodName = "TestMethodWithInVTParameter";
+        const int value = 4;
+
+        using LogListener listener = new LogListener("Created basic delegate");
+
+        TestStaticMethodWithInVTParameter caller = Accessor.GenerateStaticCaller<SampleStaticMembers, TestStaticMethodWithInVTParameter>(methodName, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a basic delegate.");
+
+        int inValue = value;
+        
+        caller(value, in inValue);
+
+        Assert.AreEqual(value, inValue);
+    }
+    private delegate void TestStaticMethodWithInRTParameter(string value, in string inValue);
+    [TestMethod]
+    public void TestBasicDelegateStaticInRTParameter()
+    {
+        const string methodName = "TestMethodWithInRTParameter";
+        const string value = "test";
+
+        using LogListener listener = new LogListener("Created basic delegate");
+
+        TestStaticMethodWithInRTParameter caller = Accessor.GenerateStaticCaller<SampleStaticMembers, TestStaticMethodWithInRTParameter>(methodName, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a basic delegate.");
+
+        string inValue = value;
+
+        caller(value, in inValue);
+
+        Assert.AreEqual(value, inValue);
+    }
+    private delegate void TestInstanceMethodWithInVTParameter(SampleClass instance, int value, in int inValue);
+    [TestMethod]
+    public void TestDynamicMethodInstanceInVTParameter()
+    {
+        const string methodName = "TestMethodWithInVTParameter";
+        const int value = 4;
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        TestInstanceMethodWithInVTParameter caller = Accessor.GenerateInstanceCaller<SampleClass, TestInstanceMethodWithInVTParameter>(methodName, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        int inValue = value;
+
+        caller(new SampleClass(), value, in inValue);
+
+        Assert.AreEqual(value, inValue);
+    }
+    private delegate void TestInstanceMethodWithInRTParameter(SampleClass instance, string value, in string inValue);
+    [TestMethod]
+    public void TestDynamicMethodInstanceInRTParameter()
+    {
+        const string methodName = "TestMethodWithInRTParameter";
+        const string value = "test";
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        TestInstanceMethodWithInRTParameter caller = Accessor.GenerateInstanceCaller<SampleClass, TestInstanceMethodWithInRTParameter>(methodName, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        string inValue = value;
+
+        caller(new SampleClass(), value, in inValue);
+
+        Assert.AreEqual(value, inValue);
+    }
+}

--- a/ReflectionTools.Tests/Accessor_GenerateInstanceCaller.cs
+++ b/ReflectionTools.Tests/Accessor_GenerateInstanceCaller.cs
@@ -1,0 +1,646 @@
+﻿using DanielWillett.ReflectionTools.Tests.SampleObjects;
+using System.Reflection;
+
+namespace DanielWillett.ReflectionTools.Tests;
+
+[TestClass]
+[TestCategory("Accessor")]
+public class Accessor_GenerateInstanceCaller
+{
+    [TestMethod]
+    public void TestRTBasicDelegateAction()
+    {
+        const string methodName = "NotImplementedNoParams";
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        Action<SampleClass> caller = Accessor.GenerateInstanceCaller<SampleClass, Action<SampleClass>>(methodName, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        SampleClass sampleClass = new SampleClass();
+
+        Assert.ThrowsException<NotImplementedException>(() => caller(sampleClass), "Method did not run.");
+    }
+    [TestMethod]
+    public void TestRTBasicDelegateActionUnsafeBinding()
+    {
+        const string methodName = "NotImplementedNoParams";
+
+        using LogListener listener = new LogListener("Created basic delegate");
+
+        Action<SampleClass> caller = Accessor.GenerateInstanceCaller<SampleClass, Action<SampleClass>>(methodName, allowUnsafeTypeBinding: true, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a basic delegate.");
+
+        SampleClass sampleClass = new SampleClass();
+
+        Assert.ThrowsException<NotImplementedException>(() => caller(sampleClass), "Method did not run.");
+    }
+    [TestMethod]
+    public void TestRTBasicDelegateActionThrowsNRE()
+    {
+        const string methodName = "NotImplementedNoParams";
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        Action<SampleClass> caller = Accessor.GenerateInstanceCaller<SampleClass, Action<SampleClass>>(methodName, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        SampleClass sampleClass = new SampleClass();
+
+        Assert.ThrowsException<NotImplementedException>(() =>
+        {
+            caller(sampleClass);
+        }, "Method did not run.");
+
+        Assert.ThrowsException<NullReferenceException>(() =>
+        {
+            caller(null!);
+        });
+    }
+    [TestMethod]
+    public void TestRTBasicDelegateRTArgThrowsNRE()
+    {
+        const string methodName = "SetRefTypeField";
+        const string value = "test";
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        Action<SampleClass, string> caller = Accessor.GenerateInstanceCaller<SampleClass, Action<SampleClass, string>>(methodName, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        SampleClass sampleClass = new SampleClass();
+
+        caller(sampleClass, value);
+
+        Assert.AreEqual(value, sampleClass.PublicRefTypeField);
+
+        Assert.ThrowsException<NullReferenceException>(() =>
+        {
+            caller(null!, value);
+        });
+    }
+    [TestMethod]
+    public void TestRTBasicDelegateActionRTArg()
+    {
+        const string methodName = "SetRefTypeField";
+        const string value = "test";
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        Action<SampleClass, string> caller = Accessor.GenerateInstanceCaller<SampleClass, Action<SampleClass, string>>(methodName, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        SampleClass sampleClass = new SampleClass();
+
+        caller(sampleClass, value);
+
+        Assert.AreEqual(value, sampleClass.PublicRefTypeField);
+    }
+    [TestMethod]
+    public void TestRTBasicDelegateActionVTArg()
+    {
+        const string methodName = "SetValTypeField";
+        const int value = 3;
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        Action<SampleClass, int> caller = Accessor.GenerateInstanceCaller<SampleClass, Action<SampleClass, int>>(methodName, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        SampleClass sampleClass = new SampleClass();
+
+        caller(sampleClass, value);
+
+        Assert.AreEqual(value, sampleClass.PublicValTypeField);
+    }
+    [TestMethod]
+    public void TestRTUnsafeTypeBindingDelegateActionObjRTArg()
+    {
+        const string methodName = "SetRefTypeField";
+        const string value = "test";
+
+        using LogListener listener = new LogListener("Created unsafely binded delegate");
+
+        Action<SampleClass, object> caller = Accessor.GenerateInstanceCaller<SampleClass, Action<SampleClass, object>>(methodName, allowUnsafeTypeBinding: true, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+#if !NET6_0_OR_GREATER
+        Assert.IsTrue(listener.Result, "Method was not created with an unsafely binded delegate.");
+#else
+        Assert.IsFalse(listener.Result, "Method created with an unsafely binded delegate on .NET 6.0 or later.");
+#endif
+
+        SampleClass sampleClass = new SampleClass();
+
+        caller(sampleClass, value);
+
+        Assert.AreEqual(value, sampleClass.PublicRefTypeField);
+    }
+    [TestMethod]
+    public void TestRTNoUnsafeTypeBindingDelegateActionBoxxedVTArg()
+    {
+        const string methodName = "SetValTypeField";
+        const int value = 3;
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        Action<SampleClass, object> caller = Accessor.GenerateInstanceCaller<SampleClass, Action<SampleClass, object>>(methodName, allowUnsafeTypeBinding: true, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        SampleClass sampleClass = new SampleClass();
+
+        caller(sampleClass, value);
+
+        Assert.AreEqual(value, sampleClass.PublicValTypeField);
+    }
+    [TestMethod]
+    public void TestRTDynamicDelegateActionObjRTArg()
+    {
+        const string methodName = "SetRefTypeField";
+        const string value = "test";
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        Action<SampleClass, object> caller = Accessor.GenerateInstanceCaller<SampleClass, Action<SampleClass, object>>(methodName, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        SampleClass sampleClass = new SampleClass();
+
+        caller(sampleClass, value);
+
+        Assert.AreEqual(value, sampleClass.PublicRefTypeField);
+    }
+    [TestMethod]
+    public void TestRTDynamicDelegateActionObjRTArgThrowsExceptions()
+    {
+        const string methodName = "SetRefTypeField";
+        const string value = "test";
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        Action<SampleClass, object?> caller = Accessor.GenerateInstanceCaller<SampleClass, Action<SampleClass, object?>>(methodName, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        SampleClass sampleClass = new SampleClass();
+
+        caller(sampleClass, value);
+
+        Assert.AreEqual(value, sampleClass.PublicRefTypeField);
+
+        caller(sampleClass, null);
+
+        Assert.AreEqual(null, sampleClass.PublicRefTypeField);
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            caller(sampleClass, 3.0f);
+        });
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            caller(sampleClass, new SampleClass());
+        });
+    }
+    [TestMethod]
+    public void TestRTDynamicDelegateActionBoxxedVTArg()
+    {
+        const string methodName = "SetValTypeField";
+        const int value = 3;
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        Action<SampleClass, object> caller = Accessor.GenerateInstanceCaller<SampleClass, Action<SampleClass, object>>(methodName, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        SampleClass sampleClass = new SampleClass();
+
+        caller(sampleClass, value);
+
+        Assert.AreEqual(value, sampleClass.PublicValTypeField);
+    }
+    [TestMethod]
+    public void TestRTDynamicDelegateActionBoxxedVTArgThrowsExceptions()
+    {
+        const string methodName = "SetValTypeField";
+        const int value = 3;
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        Action<SampleClass, object> caller = Accessor.GenerateInstanceCaller<SampleClass, Action<SampleClass, object>>(methodName, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        SampleClass sampleClass = new SampleClass();
+
+        caller(sampleClass, value);
+
+        Assert.AreEqual(value, sampleClass.PublicValTypeField);
+
+        Assert.ThrowsException<NullReferenceException>(() =>
+        {
+            caller(sampleClass, null!);
+        });
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            caller(sampleClass, 3.0f);
+        });
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            caller(sampleClass, new SampleClass());
+        });
+    }
+    [TestMethod]
+    public void TestObjectRTBasicDelegateAction()
+    {
+        const string methodName = "NotImplementedNoParams";
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        Action<object> caller = Accessor.GenerateInstanceCaller<SampleClass, Action<object>>(methodName, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        SampleClass sampleClass = new SampleClass();
+
+        Assert.ThrowsException<NotImplementedException>(() => caller(sampleClass), "Method did not run.");
+    }
+    [TestMethod]
+    public void TestObjectRTBasicDelegateActionRTArg()
+    {
+        const string methodName = "SetRefTypeField";
+        const string value = "test";
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        Action<object, string> caller = Accessor.GenerateInstanceCaller<SampleClass, Action<object, string>>(methodName, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        SampleClass sampleClass = new SampleClass();
+
+        caller(sampleClass, value);
+
+        Assert.AreEqual(value, sampleClass.PublicRefTypeField);
+    }
+    [TestMethod]
+    public void TestObjectRTBasicDelegateActionVTArg()
+    {
+        const string methodName = "SetValTypeField";
+        const int value = 3;
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        Action<object, int> caller = Accessor.GenerateInstanceCaller<SampleClass, Action<object, int>>(methodName, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        SampleClass sampleClass = new SampleClass();
+
+        caller(sampleClass, value);
+
+        Assert.AreEqual(value, sampleClass.PublicValTypeField);
+    }
+    [TestMethod]
+    public void TestObjectRTUnsafeTypeBindingDelegateActionObjRTArg()
+    {
+        const string methodName = "SetRefTypeField";
+        const string value = "test";
+
+        using LogListener listener = new LogListener("Created unsafely binded delegate");
+
+        Action<object, object> caller = Accessor.GenerateInstanceCaller<SampleClass, Action<object, object>>(methodName, allowUnsafeTypeBinding: true, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+#if !NET6_0_OR_GREATER
+        Assert.IsTrue(listener.Result, "Method was not created with an unsafely binded delegate.");
+#else
+        Assert.IsFalse(listener.Result, "Method created with an unsafely binded delegate on .NET 6.0 or later.");
+#endif
+
+        SampleClass sampleClass = new SampleClass();
+
+        caller(sampleClass, value);
+
+        Assert.AreEqual(value, sampleClass.PublicRefTypeField);
+    }
+    [TestMethod]
+    public void TestObjectRTNoUnsafeTypeBindingDelegateActionBoxxedVTArg()
+    {
+        const string methodName = "SetValTypeField";
+        const int value = 3;
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        Action<object, object> caller = Accessor.GenerateInstanceCaller<SampleClass, Action<object, object>>(methodName, allowUnsafeTypeBinding: true, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        SampleClass sampleClass = new SampleClass();
+
+        caller(sampleClass, value);
+
+        Assert.AreEqual(value, sampleClass.PublicValTypeField);
+    }
+    [TestMethod]
+    public void TestObjectRTDynamicDelegateActionObjRTArg()
+    {
+        const string methodName = "SetRefTypeField";
+        const string value = "test";
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        Action<object, object> caller = Accessor.GenerateInstanceCaller<SampleClass, Action<object, object>>(methodName, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        SampleClass sampleClass = new SampleClass();
+
+        caller(sampleClass, value);
+
+        Assert.AreEqual(value, sampleClass.PublicRefTypeField);
+    }
+    [TestMethod]
+    public void TestObjectRTDynamicDelegateActionBoxxedVTArg()
+    {
+        const string methodName = "SetValTypeField";
+        const int value = 3;
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        Action<object, object> caller = Accessor.GenerateInstanceCaller<SampleClass, Action<object, object>>(methodName, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        SampleClass sampleClass = new SampleClass();
+
+        caller(sampleClass, value);
+
+        Assert.AreEqual(value, sampleClass.PublicValTypeField);
+    }
+    [TestMethod]
+    public void TestVTBasicDelegateAction()
+    {
+        const string methodName = "NotImplementedNoParams";
+#if NET471_OR_GREATER || NET || NETCOREAPP2_0_OR_GREATER || NETSTANDARD2_1
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        Action<SampleStruct> caller = Accessor.GenerateInstanceCaller<SampleStruct, Action<SampleStruct>>(methodName, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        SampleStruct sampleClass = new SampleStruct();
+
+        Assert.ThrowsException<NotImplementedException>(() => caller(sampleClass), "Method did not run.");
+#else // unable to check for readonly methods in lower versions
+        Assert.ThrowsException<Exception>(() =>
+        {
+            _ = Accessor.GenerateInstanceCaller<SampleStruct, Action<SampleStruct>>(methodName, throwOnError: true)!;
+        }, "Threw correct exception for non-readonly method as a value type.");
+#endif
+    }
+    [TestMethod]
+    public void TestVTBasicDelegateActionRTArg()
+    {
+        const string methodName = "SetRefTypeField";
+        Assert.ThrowsException<Exception>(() =>
+        {
+            _ = Accessor.GenerateInstanceCaller<SampleStruct, Action<SampleStruct, string>>(methodName, throwOnError: true)!;
+        }, "Threw correct exception for non-readonly method as a value type.");
+    }
+    [TestMethod]
+    public void TestVTBasicDelegateActionVTArg()
+    {
+        const string methodName = "SetValTypeField";
+        Assert.ThrowsException<Exception>(() =>
+        {
+            _ = Accessor.GenerateInstanceCaller<SampleStruct, Action<SampleStruct, int>>(methodName, throwOnError: true)!;
+        }, "Threw correct exception for non-readonly method as a value type.");
+    }
+    [TestMethod]
+    public void TestVTUnsafeTypeBindingDelegateActionObjRTArg()
+    {
+        const string methodName = "SetRefTypeField";
+        Assert.ThrowsException<Exception>(() =>
+        {
+            _ = Accessor.GenerateInstanceCaller<SampleStruct, Action<SampleStruct, object>>(methodName, allowUnsafeTypeBinding: true, throwOnError: true)!;
+        }, "Threw correct exception for non-readonly method as a value type.");
+    }
+    [TestMethod]
+    public void TestVTNoUnsafeTypeBindingDelegateActionBoxxedVTArg()
+    {
+        const string methodName = "SetValTypeField";
+        Assert.ThrowsException<Exception>(() =>
+        {
+            _ = Accessor.GenerateInstanceCaller<SampleStruct, Action<SampleStruct, object>>(methodName, allowUnsafeTypeBinding: true, throwOnError: true)!;
+        }, "Threw correct exception for non-readonly method as a value type.");
+    }
+    [TestMethod]
+    public void TestVTDynamicDelegateActionObjRTArg()
+    {
+        const string methodName = "SetRefTypeField";
+        Assert.ThrowsException<Exception>(() =>
+        {
+            _ = Accessor.GenerateInstanceCaller<SampleStruct, Action<SampleStruct, object>>(methodName, throwOnError: true)!;
+        }, "Threw correct exception for non-readonly method as a value type.");
+    }
+    [TestMethod]
+    public void TestVTDynamicDelegateActionBoxxedVTArg()
+    {
+        const string methodName = "SetValTypeField";
+        Assert.ThrowsException<Exception>(() =>
+        {
+            _ = Accessor.GenerateInstanceCaller<SampleStruct, Action<SampleStruct, object>>(methodName, throwOnError: true)!;
+        }, "Threw correct exception for non-readonly method as a value type.");
+    }
+    [TestMethod]
+    public void TestBoxedVTBasicDelegateAction()
+    {
+        const string methodName = "NotImplementedNoParams";
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        MethodInfo method = typeof(SampleStruct).GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance)!;
+        Action<object> caller = Accessor.GenerateInstanceCaller<Action<object>>(method, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        object sampleClass = new SampleStruct();
+
+        Assert.ThrowsException<NotImplementedException>(() => caller(sampleClass), "Method did not run.");
+    }
+    [TestMethod]
+    public void TestBoxedVTBasicDelegateActionRTArg()
+    {
+        const string methodName = "SetRefTypeField";
+        const string value = "test";
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        MethodInfo method = typeof(SampleStruct).GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance)!;
+        Action<object, string> caller = Accessor.GenerateInstanceCaller<Action<object, string>>(method, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        object sampleClass = new SampleStruct();
+
+        caller(sampleClass, value);
+
+        Assert.AreEqual(value, ((SampleStruct)sampleClass).PublicRefTypeField);
+    }
+    [TestMethod]
+    public void TestBoxedVTBasicDelegateActionVTArg()
+    {
+        const string methodName = "SetValTypeField";
+        const int value = 3;
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        MethodInfo method = typeof(SampleStruct).GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance)!;
+        Action<object, int> caller = Accessor.GenerateInstanceCaller<Action<object, int>>(method, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        object sampleClass = new SampleStruct();
+
+        caller(sampleClass, value);
+
+        Assert.AreEqual(value, ((SampleStruct)sampleClass).PublicValTypeField);
+    }
+    [TestMethod]
+    public void TestBoxedVTUnsafeTypeBindingDelegateActionObjRTArg()
+    {
+        const string methodName = "SetRefTypeField";
+        const string value = "test";
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        MethodInfo method = typeof(SampleStruct).GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance)!;
+        Action<object, object> caller = Accessor.GenerateInstanceCaller<Action<object, object>>(method, allowUnsafeTypeBinding: true, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+        
+        Assert.IsTrue(listener.Result, "Method was not created with an dynamic method.");
+
+        object sampleClass = new SampleStruct();
+
+        caller(sampleClass, value);
+
+        Assert.AreEqual(value, ((SampleStruct)sampleClass).PublicRefTypeField);
+    }
+    [TestMethod]
+    public void TestBoxedVTNoUnsafeTypeBindingDelegateActionBoxxedVTArg()
+    {
+        const string methodName = "SetValTypeField";
+        const int value = 3;
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        MethodInfo method = typeof(SampleStruct).GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance)!;
+        Action<object, object> caller = Accessor.GenerateInstanceCaller<Action<object, object>>(method, allowUnsafeTypeBinding: true, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        object sampleClass = new SampleStruct();
+
+        caller(sampleClass, value);
+
+        Assert.AreEqual(value, ((SampleStruct)sampleClass).PublicValTypeField);
+    }
+    [TestMethod]
+    public void TestBoxedVTDynamicDelegateActionObjRTArg()
+    {
+        const string methodName = "SetRefTypeField";
+        const string value = "test";
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        MethodInfo method = typeof(SampleStruct).GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance)!;
+        Action<object, object> caller = Accessor.GenerateInstanceCaller<Action<object, object>>(method, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        object sampleClass = new SampleStruct();
+
+        caller(sampleClass, value);
+
+        Assert.AreEqual(value, ((SampleStruct)sampleClass).PublicRefTypeField);
+    }
+    [TestMethod]
+    public void TestBoxedVTDynamicDelegateActionBoxxedVTArg()
+    {
+        const string methodName = "SetValTypeField";
+        const int value = 3;
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        MethodInfo method = typeof(SampleStruct).GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance)!;
+        Action<object, object> caller = Accessor.GenerateInstanceCaller<Action<object, object>>(method, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        object sampleClass = new SampleStruct();
+
+        caller(sampleClass, value);
+
+        Assert.AreEqual(value, ((SampleStruct)sampleClass).PublicValTypeField);
+    }
+}

--- a/ReflectionTools.Tests/Accessor_GenerateInstanceGetter.cs
+++ b/ReflectionTools.Tests/Accessor_GenerateInstanceGetter.cs
@@ -1,0 +1,1401 @@
+using DanielWillett.ReflectionTools.Tests.SampleObjects;
+using System.Reflection;
+
+namespace DanielWillett.ReflectionTools.Tests;
+
+[TestClass]
+[TestCategory("Accessor")]
+public class Accessor_GenerateInstanceGetter
+{
+    /*
+     * Private value type field in reference type
+     */
+
+    [TestMethod]
+    // field: private, non-readonly, value type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as-is (value type)
+    public void TestPrivateValueTypeFieldInReferenceType()
+    {
+        const string fieldName = "_privateValTypeField";
+        const int value = 1;
+
+        InstanceGetter<SampleClass, int> getter = Accessor.GenerateInstanceGetter<SampleClass, int>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, getter(instance));
+    }
+
+    [TestMethod]
+    // field: private, non-readonly, value type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as a boxed value type
+    public void TestPrivateBoxedValueTypeFieldInReferenceType()
+    {
+        const string fieldName = "_privateValTypeField";
+        const int value = 1;
+
+        InstanceGetter<SampleClass, object> getter = Accessor.GenerateInstanceGetter<SampleClass, object>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, (int)getter(instance));
+    }
+
+    [TestMethod]
+    // field: private, non-readonly, value type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as-is (value type)
+    public void TestPrivateValueTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "_privateValTypeField";
+        const int value = 1;
+
+        InstanceGetter<object, int> getter = Accessor.GenerateInstanceGetter<int>(typeof(SampleClass), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, getter(instance));
+    }
+
+    [TestMethod]
+    // field: private, non-readonly, value type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as a boxed value type
+    public void TestPrivateBoxedValueTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "_privateValTypeField";
+        const int value = 1;
+
+        InstanceGetter<object, object> getter = Accessor.GenerateInstanceGetter<object>(typeof(SampleClass), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, (int)getter(instance));
+    }
+
+    /*
+     * Public value type field in reference type
+     */
+
+    [TestMethod]
+    // field: public, non-readonly, value type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as-is (value type)
+    public void TestPublicValueTypeFieldInReferenceType()
+    {
+        const string fieldName = "PublicValTypeField";
+        const int value = 1;
+
+        InstanceGetter<SampleClass, int> getter = Accessor.GenerateInstanceGetter<SampleClass, int>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass
+        {
+            PublicValTypeField = value
+        };
+
+        Assert.AreEqual(value, getter(instance));
+    }
+
+    [TestMethod]
+    // field: public, non-readonly, value type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as a boxed value type
+    public void TestPublicBoxedValueTypeFieldInReferenceType()
+    {
+        const string fieldName = "PublicValTypeField";
+        const int value = 1;
+
+        InstanceGetter<SampleClass, object> getter = Accessor.GenerateInstanceGetter<SampleClass, object>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass
+        {
+            PublicValTypeField = value
+        };
+
+        Assert.AreEqual(value, (int)getter(instance));
+    }
+
+    [TestMethod]
+    // field: public, non-readonly, value type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as-is (value type)
+    public void TestPublicValueTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "PublicValTypeField";
+        const int value = 1;
+
+        InstanceGetter<object, int> getter = Accessor.GenerateInstanceGetter<int>(typeof(SampleClass), fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass
+        {
+            PublicValTypeField = value
+        };
+
+        Assert.AreEqual(value, getter(instance));
+    }
+
+    [TestMethod]
+    // field: public, non-readonly, value type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as a boxed value type
+    public void TestPublicBoxedValueTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "PublicValTypeField";
+        const int value = 1;
+
+        InstanceGetter<object, object> getter = Accessor.GenerateInstanceGetter<object>(typeof(SampleClass), fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass
+        {
+            PublicValTypeField = value
+        };
+
+        Assert.AreEqual(value, (int)getter(instance));
+    }
+
+    /*
+     * Private value type field in value type
+     */
+
+    [TestMethod]
+    // field: private, non-readonly, value type
+    // instance: value type
+    // instance: passed as-is (value type)
+    // value: passed as-is (value type)
+    public void TestPrivateValueTypeFieldInValueType()
+    {
+        const string fieldName = "_privateValTypeField";
+        const int value = 1;
+
+        InstanceGetter<SampleStruct, int> getter = Accessor.GenerateInstanceGetter<SampleStruct, int>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStruct).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        object instance = new SampleStruct();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, getter((SampleStruct)instance));
+    }
+
+    [TestMethod]
+    // field: private, non-readonly, value type
+    // instance: value type
+    // instance: passed as-is (value type)
+    // value: passed as a boxed value type
+    public void TestPrivateBoxedValueTypeFieldInValueType()
+    {
+        const string fieldName = "_privateValTypeField";
+        const int value = 1;
+
+        InstanceGetter<SampleStruct, object> getter = Accessor.GenerateInstanceGetter<SampleStruct, object>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStruct).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        object instance = new SampleStruct();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, (int)getter((SampleStruct)instance));
+    }
+
+    [TestMethod]
+    // field: private, non-readonly, value type
+    // instance: value type
+    // instance: passed as a boxed value type
+    // value: passed as-is (value type)
+    public void TestPrivateValueTypeFieldInObjectValueType()
+    {
+        const string fieldName = "_privateValTypeField";
+        const int value = 1;
+
+        InstanceGetter<object, int> getter = Accessor.GenerateInstanceGetter<int>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStruct).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        object instance = new SampleStruct();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, getter(instance));
+    }
+
+    [TestMethod]
+    // field: private, non-readonly, value type
+    // instance: value type
+    // instance: passed as a boxed value type
+    // value: passed as a boxed value type
+    public void TestPrivateBoxedValueTypeFieldInObjectValueType()
+    {
+        const string fieldName = "_privateValTypeField";
+        const int value = 1;
+
+        InstanceGetter<object, object> getter = Accessor.GenerateInstanceGetter<object>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStruct).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        object instance = new SampleStruct();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, (int)getter((SampleStruct)instance));
+    }
+
+    /*
+     * Public value type field in value type
+     */
+
+    [TestMethod]
+    // field: public, non-readonly, value type
+    // instance: value type
+    // instance: passed as-is
+    // value: passed as-is (value type)
+    public void TestPublicValueTypeFieldInValueType()
+    {
+        const string fieldName = "PublicValTypeField";
+        const int value = 1;
+
+        InstanceGetter<SampleStruct, int> getter = Accessor.GenerateInstanceGetter<SampleStruct, int>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+        SampleStruct instance = new SampleStruct
+        {
+            PublicValTypeField = value
+        };
+
+        Assert.AreEqual(value, getter(instance));
+    }
+
+    [TestMethod]
+    // field: public, non-readonly, value type
+    // instance: value type
+    // instance: passed as-is
+    // value: passed as a boxed value type
+    public void TestPublicBoxedValueTypeFieldInValueType()
+    {
+        const string fieldName = "PublicValTypeField";
+        const int value = 1;
+
+        InstanceGetter<SampleStruct, object> getter = Accessor.GenerateInstanceGetter<SampleStruct, object>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+        SampleStruct instance = new SampleStruct
+        {
+            PublicValTypeField = value
+        };
+
+        Assert.AreEqual(value, (int)getter(instance));
+    }
+
+    [TestMethod]
+    // field: public, non-readonly, value type
+    // instance: value type
+    // instance: passed as an object
+    // value: passed as-is (value type)
+    public void TestPublicValueTypeFieldInObjectValueType()
+    {
+        const string fieldName = "PublicValTypeField";
+        const int value = 1;
+
+        InstanceGetter<object, int> getter = Accessor.GenerateInstanceGetter<int>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+        SampleStruct instance = new SampleStruct
+        {
+            PublicValTypeField = value
+        };
+
+        Assert.AreEqual(value, getter(instance));
+    }
+
+    [TestMethod]
+    // field: public, non-readonly, value type
+    // instance: value type
+    // instance: passed as an object
+    // value: passed as a boxed value type
+    public void TestPublicBoxedValueTypeFieldInObjectValueType()
+    {
+        const string fieldName = "PublicValTypeField";
+        const int value = 1;
+
+        InstanceGetter<object, object> getter = Accessor.GenerateInstanceGetter<object>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(getter);
+
+        SampleStruct instance = new SampleStruct
+        {
+            PublicValTypeField = value
+        };
+
+        Assert.AreEqual(value, (int)getter(instance));
+    }
+
+    /*
+     * Private reference type field in reference type
+     */
+
+    [TestMethod]
+    // field: private, non-readonly, reference type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as-is (value type)
+    public void TestPrivateReferenceTypeFieldInReferenceType()
+    {
+        const string fieldName = "_privateRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<SampleClass, string> getter = Accessor.GenerateInstanceGetter<SampleClass, string>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, getter(instance));
+    }
+
+    [TestMethod]
+    // field: private, non-readonly, reference type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as a boxed value type
+    public void TestPrivateObjectReferenceTypeFieldInReferenceType()
+    {
+        const string fieldName = "_privateRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<SampleClass, object> getter = Accessor.GenerateInstanceGetter<SampleClass, object>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, (string)getter(instance));
+    }
+
+    [TestMethod]
+    // field: private, non-readonly, reference type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as-is (value type)
+    public void TestPrivateReferenceTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "_privateRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<object, string> getter = Accessor.GenerateInstanceGetter<string>(typeof(SampleClass), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, getter(instance));
+    }
+
+    [TestMethod]
+    // field: private, non-readonly, reference type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as a boxed value type
+    public void TestPrivateObjectReferenceTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "_privateRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<object, object> getter = Accessor.GenerateInstanceGetter<object>(typeof(SampleClass), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, (string)getter(instance));
+    }
+
+    /*
+     * Public reference type field in reference type
+     */
+
+    [TestMethod]
+    // field: public, non-readonly, reference type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as-is (value type)
+    public void TestPublicReferenceTypeFieldInReferenceType()
+    {
+        const string fieldName = "PublicRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<SampleClass, string> getter = Accessor.GenerateInstanceGetter<SampleClass, string>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass
+        {
+            PublicRefTypeField = value
+        };
+
+        Assert.AreEqual(value, getter(instance));
+    }
+
+    [TestMethod]
+    // field: public, non-readonly, reference type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as a boxed value type
+    public void TestPublicObjectReferenceTypeFieldInReferenceType()
+    {
+        const string fieldName = "PublicRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<SampleClass, object> getter = Accessor.GenerateInstanceGetter<SampleClass, object>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass
+        {
+            PublicRefTypeField = value
+        };
+
+        Assert.AreEqual(value, (string)getter(instance));
+    }
+
+    [TestMethod]
+    // field: public, non-readonly, reference type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as-is (value type)
+    public void TestPublicReferenceTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "PublicRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<object, string> getter = Accessor.GenerateInstanceGetter<string>(typeof(SampleClass), fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass
+        {
+            PublicRefTypeField = value
+        };
+
+        Assert.AreEqual(value, getter(instance));
+    }
+
+    [TestMethod]
+    // field: public, non-readonly, reference type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as a boxed value type
+    public void TestPublicObjectReferenceTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "PublicRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<object, object> getter = Accessor.GenerateInstanceGetter<object>(typeof(SampleClass), fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass
+        {
+            PublicRefTypeField = value
+        };
+
+        Assert.AreEqual(value, (string)getter(instance));
+    }
+
+    /*
+     * Private reference type field in value type
+     */
+
+    [TestMethod]
+    // field: private, non-readonly, reference type
+    // instance: value type
+    // instance: passed as-is (value type)
+    // value: passed as-is (value type)
+    public void TestPrivateReferenceTypeFieldInValueType()
+    {
+        const string fieldName = "_privateRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<SampleStruct, string> getter = Accessor.GenerateInstanceGetter<SampleStruct, string>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStruct).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        object instance = new SampleStruct();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, getter((SampleStruct)instance));
+    }
+
+    [TestMethod]
+    // field: private, non-readonly, reference type
+    // instance: value type
+    // instance: passed as-is (value type)
+    // value: passed as a boxed value type
+    public void TestPrivateObjectReferenceTypeFieldInValueType()
+    {
+        const string fieldName = "_privateRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<SampleStruct, object> getter = Accessor.GenerateInstanceGetter<SampleStruct, object>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStruct).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        object instance = new SampleStruct();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, (string)getter((SampleStruct)instance));
+    }
+
+    [TestMethod]
+    // field: private, non-readonly, reference type
+    // instance: value type
+    // instance: passed as a boxed value type
+    // value: passed as-is (value type)
+    public void TestPrivateReferenceTypeFieldInObjectValueType()
+    {
+        const string fieldName = "_privateRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<object, string> getter = Accessor.GenerateInstanceGetter<string>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStruct).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        object instance = new SampleStruct();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, getter(instance));
+    }
+
+    [TestMethod]
+    // field: private, non-readonly, reference type
+    // instance: value type
+    // instance: passed as a boxed value type
+    // value: passed as a boxed value type
+    public void TestPrivateObjectReferenceTypeFieldInObjectValueType()
+    {
+        const string fieldName = "_privateRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<object, object> getter = Accessor.GenerateInstanceGetter<object>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStruct).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        object instance = new SampleStruct();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, (string)getter((SampleStruct)instance));
+    }
+
+    /*
+     * Public reference type field in value type
+     */
+
+    [TestMethod]
+    // field: public, non-readonly, reference type
+    // instance: value type
+    // instance: passed as-is
+    // value: passed as-is (value type)
+    public void TestPublicReferenceTypeFieldInValueType()
+    {
+        const string fieldName = "PublicRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<SampleStruct, string> getter = Accessor.GenerateInstanceGetter<SampleStruct, string>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+        SampleStruct instance = new SampleStruct
+        {
+            PublicRefTypeField = value
+        };
+
+        Assert.AreEqual(value, getter(instance));
+    }
+
+    [TestMethod]
+    // field: public, non-readonly, reference type
+    // instance: value type
+    // instance: passed as-is
+    // value: passed as a boxed value type
+    public void TestPublicObjectReferenceTypeFieldInValueType()
+    {
+        const string fieldName = "PublicRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<SampleStruct, object> getter = Accessor.GenerateInstanceGetter<SampleStruct, object>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+        SampleStruct instance = new SampleStruct
+        {
+            PublicRefTypeField = value
+        };
+
+        Assert.AreEqual(value, (string)getter(instance));
+    }
+
+    [TestMethod]
+    // field: public, non-readonly, reference type
+    // instance: value type
+    // instance: passed as an object
+    // value: passed as-is (value type)
+    public void TestPublicReferenceTypeFieldInObjectValueType()
+    {
+        const string fieldName = "PublicRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<object, string> getter = Accessor.GenerateInstanceGetter<string>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+        SampleStruct instance = new SampleStruct
+        {
+            PublicRefTypeField = value
+        };
+
+        Assert.AreEqual(value, getter(instance));
+    }
+
+    [TestMethod]
+    // field: public, non-readonly, reference type
+    // instance: value type
+    // instance: passed as an object
+    // value: passed as a boxed value type
+    public void TestPublicObjectReferenceTypeFieldInObjectValueType()
+    {
+        const string fieldName = "PublicRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<object, object> getter = Accessor.GenerateInstanceGetter<object>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(getter);
+
+        SampleStruct instance = new SampleStruct
+        {
+            PublicRefTypeField = value
+        };
+
+        Assert.AreEqual(value, (string)getter(instance));
+    }
+
+    /*
+     * Private readonly value type field in reference type
+     */
+
+    [TestMethod]
+    // field: private, readonly, value type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as-is (value type)
+    public void TestReadonlyPrivateValueTypeFieldInReferenceType()
+    {
+        const string fieldName = "_privateReadonlyValTypeField";
+        const int value = 1;
+
+        InstanceGetter<SampleClass, int> getter = Accessor.GenerateInstanceGetter<SampleClass, int>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, getter(instance));
+    }
+
+    [TestMethod]
+    // field: private, readonly, value type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as a boxed value type
+    public void TestReadonlyPrivateBoxedValueTypeFieldInReferenceType()
+    {
+        const string fieldName = "_privateReadonlyValTypeField";
+        const int value = 1;
+
+        InstanceGetter<SampleClass, object> getter = Accessor.GenerateInstanceGetter<SampleClass, object>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, (int)getter(instance));
+    }
+
+    [TestMethod]
+    // field: private, readonly, value type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as-is (value type)
+    public void TestReadonlyPrivateValueTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "_privateReadonlyValTypeField";
+        const int value = 1;
+
+        InstanceGetter<object, int> getter = Accessor.GenerateInstanceGetter<int>(typeof(SampleClass), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, getter(instance));
+    }
+
+    [TestMethod]
+    // field: private, readonly, value type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as a boxed value type
+    public void TestReadonlyPrivateBoxedValueTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "_privateReadonlyValTypeField";
+        const int value = 1;
+
+        InstanceGetter<object, object> getter = Accessor.GenerateInstanceGetter<object>(typeof(SampleClass), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, (int)getter(instance));
+    }
+
+    /*
+     * Public readonly value type field in reference type
+     */
+
+    [TestMethod]
+    // field: public, readonly, value type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as-is (value type)
+    public void TestReadonlyPublicValueTypeFieldInReferenceType()
+    {
+        const string fieldName = "PublicReadonlyValTypeField";
+        const int value = 1;
+
+        InstanceGetter<SampleClass, int> getter = Accessor.GenerateInstanceGetter<SampleClass, int>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass(value, null);
+
+        Assert.AreEqual(value, getter(instance));
+    }
+
+    [TestMethod]
+    // field: public, readonly, value type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as a boxed value type
+    public void TestReadonlyPublicBoxedValueTypeFieldInReferenceType()
+    {
+        const string fieldName = "PublicReadonlyValTypeField";
+        const int value = 1;
+
+        InstanceGetter<SampleClass, object> getter = Accessor.GenerateInstanceGetter<SampleClass, object>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass(value, null);
+
+        Assert.AreEqual(value, (int)getter(instance));
+    }
+
+    [TestMethod]
+    // field: public, readonly, value type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as-is (value type)
+    public void TestReadonlyPublicValueTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "PublicReadonlyValTypeField";
+        const int value = 1;
+
+        InstanceGetter<object, int> getter = Accessor.GenerateInstanceGetter<int>(typeof(SampleClass), fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass(value, null);
+
+        Assert.AreEqual(value, getter(instance));
+    }
+
+    [TestMethod]
+    // field: public, readonly, value type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as a boxed value type
+    public void TestReadonlyPublicBoxedValueTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "PublicReadonlyValTypeField";
+        const int value = 1;
+
+        InstanceGetter<object, object> getter = Accessor.GenerateInstanceGetter<object>(typeof(SampleClass), fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass(value, null);
+
+        Assert.AreEqual(value, (int)getter(instance));
+    }
+
+    /*
+     * Private readonly value type field in value type
+     */
+
+    [TestMethod]
+    // field: private, readonly, value type
+    // instance: value type
+    // instance: passed as-is (value type)
+    // value: passed as-is (value type)
+    public void TestReadonlyPrivateValueTypeFieldInValueType()
+    {
+        const string fieldName = "_privateReadonlyValTypeField";
+        const int value = 1;
+
+        InstanceGetter<SampleStruct, int> getter = Accessor.GenerateInstanceGetter<SampleStruct, int>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStruct).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        object instance = new SampleStruct();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, getter((SampleStruct)instance));
+    }
+
+    [TestMethod]
+    // field: private, readonly, value type
+    // instance: value type
+    // instance: passed as-is (value type)
+    // value: passed as a boxed value type
+    public void TestReadonlyPrivateBoxedValueTypeFieldInValueType()
+    {
+        const string fieldName = "_privateReadonlyValTypeField";
+        const int value = 1;
+
+        InstanceGetter<SampleStruct, object> getter = Accessor.GenerateInstanceGetter<SampleStruct, object>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStruct).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        object instance = new SampleStruct();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, (int)getter((SampleStruct)instance));
+    }
+
+    [TestMethod]
+    // field: private, readonly, value type
+    // instance: value type
+    // instance: passed as a boxed value type
+    // value: passed as-is (value type)
+    public void TestReadonlyPrivateValueTypeFieldInObjectValueType()
+    {
+        const string fieldName = "_privateReadonlyValTypeField";
+        const int value = 1;
+
+        InstanceGetter<object, int> getter = Accessor.GenerateInstanceGetter<int>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStruct).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        object instance = new SampleStruct();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, getter(instance));
+    }
+
+    [TestMethod]
+    // field: private, readonly, value type
+    // instance: value type
+    // instance: passed as a boxed value type
+    // value: passed as a boxed value type
+    public void TestReadonlyPrivateBoxedValueTypeFieldInObjectValueType()
+    {
+        const string fieldName = "_privateReadonlyValTypeField";
+        const int value = 1;
+
+        InstanceGetter<object, object> getter = Accessor.GenerateInstanceGetter<object>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStruct).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        object instance = new SampleStruct();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, (int)getter((SampleStruct)instance));
+    }
+
+    /*
+     * Public readonly value type field in value type
+     */
+
+    [TestMethod]
+    // field: public, readonly, value type
+    // instance: value type
+    // instance: passed as-is
+    // value: passed as-is (value type)
+    public void TestReadonlyPublicValueTypeFieldInValueType()
+    {
+        const string fieldName = "PublicReadonlyValTypeField";
+        const int value = 1;
+
+        InstanceGetter<SampleStruct, int> getter = Accessor.GenerateInstanceGetter<SampleStruct, int>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+        SampleStruct instance = new SampleStruct(value, null);
+
+        Assert.AreEqual(value, getter(instance));
+    }
+
+    [TestMethod]
+    // field: public, readonly, value type
+    // instance: value type
+    // instance: passed as-is
+    // value: passed as a boxed value type
+    public void TestReadonlyPublicBoxedValueTypeFieldInValueType()
+    {
+        const string fieldName = "PublicReadonlyValTypeField";
+        const int value = 1;
+
+        InstanceGetter<SampleStruct, object> getter = Accessor.GenerateInstanceGetter<SampleStruct, object>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+        SampleStruct instance = new SampleStruct(value, null);
+
+        Assert.AreEqual(value, (int)getter(instance));
+    }
+
+    [TestMethod]
+    // field: public, readonly, value type
+    // instance: value type
+    // instance: passed as an object
+    // value: passed as-is (value type)
+    public void TestReadonlyPublicValueTypeFieldInObjectValueType()
+    {
+        const string fieldName = "PublicReadonlyValTypeField";
+        const int value = 1;
+
+        InstanceGetter<object, int> getter = Accessor.GenerateInstanceGetter<int>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+        SampleStruct instance = new SampleStruct(value, null);
+
+        Assert.AreEqual(value, getter(instance));
+    }
+
+    [TestMethod]
+    // field: public, readonly, value type
+    // instance: value type
+    // instance: passed as an object
+    // value: passed as a boxed value type
+    public void TestReadonlyPublicBoxedValueTypeFieldInObjectValueType()
+    {
+        const string fieldName = "PublicReadonlyValTypeField";
+        const int value = 1;
+
+        InstanceGetter<object, object> getter = Accessor.GenerateInstanceGetter<object>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(getter);
+
+        SampleStruct instance = new SampleStruct(value, null);
+
+        Assert.AreEqual(value, (int)getter(instance));
+    }
+
+    /*
+     * Private readonly reference type field in reference type
+     */
+
+    [TestMethod]
+    // field: private, readonly, reference type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as-is (value type)
+    public void TestReadonlyPrivateReferenceTypeFieldInReferenceType()
+    {
+        const string fieldName = "_privateReadonlyRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<SampleClass, string> getter = Accessor.GenerateInstanceGetter<SampleClass, string>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, getter(instance));
+    }
+
+    [TestMethod]
+    // field: private, readonly, reference type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as a boxed value type
+    public void TestReadonlyPrivateObjectReferenceTypeFieldInReferenceType()
+    {
+        const string fieldName = "_privateReadonlyRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<SampleClass, object> getter = Accessor.GenerateInstanceGetter<SampleClass, object>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, (string)getter(instance));
+    }
+
+    [TestMethod]
+    // field: private, readonly, reference type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as-is (value type)
+    public void TestReadonlyPrivateReferenceTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "_privateReadonlyRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<object, string> getter = Accessor.GenerateInstanceGetter<string>(typeof(SampleClass), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, getter(instance));
+    }
+
+    [TestMethod]
+    // field: private, readonly, reference type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as a boxed value type
+    public void TestReadonlyPrivateObjectReferenceTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "_privateReadonlyRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<object, object> getter = Accessor.GenerateInstanceGetter<object>(typeof(SampleClass), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, (string)getter(instance));
+    }
+
+    /*
+     * Public readonly reference type field in reference type
+     */
+
+    [TestMethod]
+    // field: public, readonly, reference type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as-is (value type)
+    public void TestReadonlyPublicReferenceTypeFieldInReferenceType()
+    {
+        const string fieldName = "PublicReadonlyRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<SampleClass, string> getter = Accessor.GenerateInstanceGetter<SampleClass, string>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass(0, value);
+
+        Assert.AreEqual(value, getter(instance));
+    }
+
+    [TestMethod]
+    // field: public, readonly, reference type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as a boxed value type
+    public void TestReadonlyPublicObjectReferenceTypeFieldInReferenceType()
+    {
+        const string fieldName = "PublicReadonlyRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<SampleClass, object> getter = Accessor.GenerateInstanceGetter<SampleClass, object>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass(0, value);
+
+        Assert.AreEqual(value, (string)getter(instance));
+    }
+
+    [TestMethod]
+    // field: public, readonly, reference type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as-is (value type)
+    public void TestReadonlyPublicReferenceTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "PublicReadonlyRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<object, string> getter = Accessor.GenerateInstanceGetter<string>(typeof(SampleClass), fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass(0, value);
+
+        Assert.AreEqual(value, getter(instance));
+    }
+
+    [TestMethod]
+    // field: public, readonly, reference type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as a boxed value type
+    public void TestReadonlyPublicObjectReferenceTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "PublicReadonlyRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<object, object> getter = Accessor.GenerateInstanceGetter<object>(typeof(SampleClass), fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(getter);
+
+        SampleClass instance = new SampleClass(0, value);
+
+        Assert.AreEqual(value, (string)getter(instance));
+    }
+
+    /*
+     * Private readonly reference type field in value type
+     */
+
+    [TestMethod]
+    // field: private, readonly, reference type
+    // instance: value type
+    // instance: passed as-is (value type)
+    // value: passed as-is (value type)
+    public void TestReadonlyPrivateReferenceTypeFieldInValueType()
+    {
+        const string fieldName = "_privateReadonlyRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<SampleStruct, string> getter = Accessor.GenerateInstanceGetter<SampleStruct, string>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStruct).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        object instance = new SampleStruct();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, getter((SampleStruct)instance));
+    }
+
+    [TestMethod]
+    // field: private, readonly, reference type
+    // instance: value type
+    // instance: passed as-is (value type)
+    // value: passed as a boxed value type
+    public void TestReadonlyPrivateObjectReferenceTypeFieldInValueType()
+    {
+        const string fieldName = "_privateReadonlyRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<SampleStruct, object> getter = Accessor.GenerateInstanceGetter<SampleStruct, object>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStruct).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        object instance = new SampleStruct();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, (string)getter((SampleStruct)instance));
+    }
+
+    [TestMethod]
+    // field: private, readonly, reference type
+    // instance: value type
+    // instance: passed as a boxed value type
+    // value: passed as-is (value type)
+    public void TestReadonlyPrivateReferenceTypeFieldInObjectValueType()
+    {
+        const string fieldName = "_privateReadonlyRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<object, string> getter = Accessor.GenerateInstanceGetter<string>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStruct).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        object instance = new SampleStruct();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, getter(instance));
+    }
+
+    [TestMethod]
+    // field: private, readonly, reference type
+    // instance: value type
+    // instance: passed as a boxed value type
+    // value: passed as a boxed value type
+    public void TestReadonlyPrivateObjectReferenceTypeFieldInObjectValueType()
+    {
+        const string fieldName = "_privateReadonlyRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<object, object> getter = Accessor.GenerateInstanceGetter<object>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStruct).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(getter);
+
+        object instance = new SampleStruct();
+        field.SetValue(instance, value);
+
+        Assert.AreEqual(value, (string)getter((SampleStruct)instance));
+    }
+
+    /*
+     * Public readonly reference type field in value type
+     */
+
+    [TestMethod]
+    // field: public, readonly, reference type
+    // instance: value type
+    // instance: passed as-is
+    // value: passed as-is (value type)
+    public void TestReadonlyPublicReferenceTypeFieldInValueType()
+    {
+        const string fieldName = "PublicReadonlyRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<SampleStruct, string> getter = Accessor.GenerateInstanceGetter<SampleStruct, string>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+        SampleStruct instance = new SampleStruct(0, value);
+
+        Assert.AreEqual(value, getter(instance));
+    }
+
+    [TestMethod]
+    // field: public, readonly, reference type
+    // instance: value type
+    // instance: passed as-is
+    // value: passed as a boxed value type
+    public void TestReadonlyPublicObjectReferenceTypeFieldInValueType()
+    {
+        const string fieldName = "PublicReadonlyRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<SampleStruct, object> getter = Accessor.GenerateInstanceGetter<SampleStruct, object>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+        SampleStruct instance = new SampleStruct(0, value);
+
+        Assert.AreEqual(value, (string)getter(instance));
+    }
+
+    [TestMethod]
+    // field: public, readonly, reference type
+    // instance: value type
+    // instance: passed as an object
+    // value: passed as-is (value type)
+    public void TestReadonlyPublicReferenceTypeFieldInObjectValueType()
+    {
+        const string fieldName = "PublicReadonlyRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<object, string> getter = Accessor.GenerateInstanceGetter<string>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+        SampleStruct instance = new SampleStruct(0, value);
+
+        Assert.AreEqual(value, getter(instance));
+    }
+
+    [TestMethod]
+    // field: public, readonly, reference type
+    // instance: value type
+    // instance: passed as an object
+    // value: passed as a boxed value type
+    public void TestReadonlyPublicObjectReferenceTypeFieldInObjectValueType()
+    {
+        const string fieldName = "PublicReadonlyRefTypeField";
+        const string value = "test";
+
+        InstanceGetter<object, object> getter = Accessor.GenerateInstanceGetter<object>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(getter);
+
+        SampleStruct instance = new SampleStruct(0, value);
+
+        Assert.AreEqual(value, (string)getter(instance));
+    }
+}

--- a/ReflectionTools.Tests/Accessor_GenerateInstanceSetter.cs
+++ b/ReflectionTools.Tests/Accessor_GenerateInstanceSetter.cs
@@ -1,0 +1,1297 @@
+using DanielWillett.ReflectionTools.Tests.SampleObjects;
+using System.Reflection;
+
+namespace DanielWillett.ReflectionTools.Tests;
+
+[TestClass]
+[TestCategory("Accessor")]
+public class Accessor_GenerateInstanceSetter
+{
+    /*
+     * Private value type field in reference type
+     */
+
+    [TestMethod]
+    // field: private, non-readonly, value type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as-is (value type)
+    public void TestPrivateValueTypeFieldInReferenceType()
+    {
+        const string fieldName = "_privateValTypeField";
+        const int value = 1;
+
+        InstanceSetter<SampleClass, int> setter = Accessor.GenerateInstanceSetter<SampleClass, int>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, field.GetValue(instance));
+    }
+
+    [TestMethod]
+    // field: private, non-readonly, value type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as a boxed value type
+    public void TestPrivateBoxedValueTypeFieldInReferenceType()
+    {
+        const string fieldName = "_privateValTypeField";
+        const int value = 1;
+
+        InstanceSetter<SampleClass, object> setter = Accessor.GenerateInstanceSetter<SampleClass, object>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, field.GetValue(instance));
+    }
+
+    [TestMethod]
+    // field: private, non-readonly, value type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as-is (value type)
+    public void TestPrivateValueTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "_privateValTypeField";
+        const int value = 1;
+
+        InstanceSetter<object, int> setter = Accessor.GenerateInstanceSetter<int>(typeof(SampleClass), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, field.GetValue(instance));
+    }
+
+    [TestMethod]
+    // field: private, non-readonly, value type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as a boxed value type
+    public void TestPrivateBoxedValueTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "_privateValTypeField";
+        const int value = 1;
+
+        InstanceSetter<object, object> setter = Accessor.GenerateInstanceSetter<object>(typeof(SampleClass), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, field.GetValue(instance));
+    }
+
+    /*
+     * Public value type field in reference type
+     */
+
+    [TestMethod]
+    // field: public, non-readonly, value type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as-is (value type)
+    public void TestPublicValueTypeFieldInReferenceType()
+    {
+        const string fieldName = "PublicValTypeField";
+        const int value = 1;
+
+        InstanceSetter<SampleClass, int> setter = Accessor.GenerateInstanceSetter<SampleClass, int>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(setter);
+        
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, instance.PublicValTypeField);
+    }
+
+    [TestMethod]
+    // field: public, non-readonly, value type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as a boxed value type
+    public void TestPublicBoxedValueTypeFieldInReferenceType()
+    {
+        const string fieldName = "PublicValTypeField";
+        const int value = 1;
+
+        InstanceSetter<SampleClass, object> setter = Accessor.GenerateInstanceSetter<SampleClass, object>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, instance.PublicValTypeField);
+    }
+
+    [TestMethod]
+    // field: public, non-readonly, value type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as-is (value type)
+    public void TestPublicValueTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "PublicValTypeField";
+        const int value = 1;
+
+        InstanceSetter<object, int> setter = Accessor.GenerateInstanceSetter<int>(typeof(SampleClass), fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, instance.PublicValTypeField);
+    }
+
+    [TestMethod]
+    // field: public, non-readonly, value type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as a boxed value type
+    public void TestPublicBoxedValueTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "PublicValTypeField";
+        const int value = 1;
+
+        InstanceSetter<object, object> setter = Accessor.GenerateInstanceSetter<object>(typeof(SampleClass), fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, instance.PublicValTypeField);
+    }
+
+    /*
+     * Private value type field in value type
+     */
+
+    [TestMethod]
+    // field: private, non-readonly, value type
+    // instance: value type
+    // instance: passed as-is (value type)
+    // value: passed as-is (value type)
+    public void TestPrivateValueTypeFieldInValueType()
+    {
+        const string fieldName = "_privateValTypeField";
+
+        Assert.ThrowsException<Exception>(() =>
+        {
+            _ = Accessor.GenerateInstanceSetter<SampleStruct, int>(fieldName, throwOnError: true)!;
+        }, "Does not throw exceptions for setting value types.");
+    }
+
+    [TestMethod]
+    // field: private, non-readonly, value type
+    // instance: value type
+    // instance: passed as-is (value type)
+    // value: passed as a boxed value type
+    public void TestPrivateBoxedValueTypeFieldInValueType()
+    {
+        const string fieldName = "_privateValTypeField";
+
+        Assert.ThrowsException<Exception>(() =>
+        {
+            _ = Accessor.GenerateInstanceSetter<SampleStruct, int>(fieldName, throwOnError: true)!;
+        }, "Does not throw exceptions for setting value types.");
+    }
+
+    [TestMethod]
+    // field: private, non-readonly, value type
+    // instance: value type
+    // instance: passed as a boxed value type
+    // value: passed as-is (value type)
+    public void TestPrivateValueTypeFieldInObjectValueType()
+    {
+        const string fieldName = "_privateValTypeField";
+        const int value = 1;
+
+        InstanceSetter<object, int> setter = Accessor.GenerateInstanceSetter<int>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStruct).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(setter);
+
+        object instance = new SampleStruct();
+        setter(instance, value);
+
+        Assert.AreEqual(value, field.GetValue(instance));
+    }
+
+    [TestMethod]
+    // field: private, non-readonly, value type
+    // instance: value type
+    // instance: passed as a boxed value type
+    // value: passed as a boxed value type
+    public void TestPrivateBoxedValueTypeFieldInObjectValueType()
+    {
+        const string fieldName = "_privateValTypeField";
+        const int value = 1;
+
+        InstanceSetter<object, object> setter = Accessor.GenerateInstanceSetter<object>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStruct).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(setter);
+
+        object instance = new SampleStruct();
+        setter(instance, value);
+
+        Assert.AreEqual(value, field.GetValue(instance));
+    }
+
+    /*
+     * Public value type field in value type
+     */
+
+    [TestMethod]
+    // field: public, non-readonly, value type
+    // instance: value type
+    // instance: passed as-is
+    // value: passed as-is (value type)
+    public void TestPublicValueTypeFieldInValueType()
+    {
+        const string fieldName = "PublicValTypeField";
+
+        Assert.ThrowsException<Exception>(() =>
+        {
+            _ = Accessor.GenerateInstanceSetter<SampleStruct, int>(fieldName, throwOnError: true)!;
+        }, "Does not throw exceptions for setting value types.");
+    }
+
+    [TestMethod]
+    // field: public, non-readonly, value type
+    // instance: value type
+    // instance: passed as-is
+    // value: passed as a boxed value type
+    public void TestPublicBoxedValueTypeFieldInValueType()
+    {
+        const string fieldName = "PublicValTypeField";
+        
+        Assert.ThrowsException<Exception>(() =>
+        {
+            _ = Accessor.GenerateInstanceSetter<SampleStruct, object>(fieldName, throwOnError: true)!;
+        }, "Does not throw exceptions for setting value types.");
+    }
+
+    [TestMethod]
+    // field: public, non-readonly, value type
+    // instance: value type
+    // instance: passed as an object
+    // value: passed as-is (value type)
+    public void TestPublicValueTypeFieldInObjectValueType()
+    {
+        const string fieldName = "PublicValTypeField";
+        const int value = 1;
+
+        InstanceSetter<object, int> setter = Accessor.GenerateInstanceSetter<int>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(setter);
+
+        object instance = new SampleStruct();
+        setter(instance, value);
+
+        Assert.AreEqual(value, ((SampleStruct)instance).PublicValTypeField);
+    }
+
+    [TestMethod]
+    // field: public, non-readonly, value type
+    // instance: value type
+    // instance: passed as an object
+    // value: passed as a boxed value type
+    public void TestPublicBoxedValueTypeFieldInObjectValueType()
+    {
+        const string fieldName = "PublicValTypeField";
+        const int value = 1;
+
+        InstanceSetter<object, object> setter = Accessor.GenerateInstanceSetter<object>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(setter);
+
+        object instance = new SampleStruct();
+        setter(instance, value);
+
+        Assert.AreEqual(value, ((SampleStruct)instance).PublicValTypeField);
+    }
+
+    /*
+     * Private reference type field in reference type
+     */
+
+    [TestMethod]
+    // field: private, non-readonly, reference type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as-is (value type)
+    public void TestPrivateReferenceTypeFieldInReferenceType()
+    {
+        const string fieldName = "_privateRefTypeField";
+        const string value = "test";
+
+        InstanceSetter<SampleClass, string> setter = Accessor.GenerateInstanceSetter<SampleClass, string>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, field.GetValue(instance));
+    }
+
+    [TestMethod]
+    // field: private, non-readonly, reference type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as a boxed value type
+    public void TestPrivateObjectReferenceTypeFieldInReferenceType()
+    {
+        const string fieldName = "_privateRefTypeField";
+        const string value = "test";
+
+        InstanceSetter<SampleClass, object> setter = Accessor.GenerateInstanceSetter<SampleClass, object>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, field.GetValue(instance));
+    }
+
+    [TestMethod]
+    // field: private, non-readonly, reference type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as-is (value type)
+    public void TestPrivateReferenceTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "_privateRefTypeField";
+        const string value = "test";
+
+        InstanceSetter<object, string> setter = Accessor.GenerateInstanceSetter<string>(typeof(SampleClass), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, field.GetValue(instance));
+    }
+
+    [TestMethod]
+    // field: private, non-readonly, reference type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as a boxed value type
+    public void TestPrivateObjectReferenceTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "_privateRefTypeField";
+        const string value = "test";
+
+        InstanceSetter<object, object> setter = Accessor.GenerateInstanceSetter<object>(typeof(SampleClass), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, field.GetValue(instance));
+    }
+
+    /*
+     * Public reference type field in reference type
+     */
+
+    [TestMethod]
+    // field: public, non-readonly, reference type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as-is (value type)
+    public void TestPublicReferenceTypeFieldInReferenceType()
+    {
+        const string fieldName = "PublicRefTypeField";
+        const string value = "test";
+
+        InstanceSetter<SampleClass, string> setter = Accessor.GenerateInstanceSetter<SampleClass, string>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, instance.PublicRefTypeField);
+    }
+
+    [TestMethod]
+    // field: public, non-readonly, reference type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as a boxed value type
+    public void TestPublicObjectReferenceTypeFieldInReferenceType()
+    {
+        const string fieldName = "PublicRefTypeField";
+        const string value = "test";
+
+        InstanceSetter<SampleClass, object> setter = Accessor.GenerateInstanceSetter<SampleClass, object>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, instance.PublicRefTypeField);
+    }
+
+    [TestMethod]
+    // field: public, non-readonly, reference type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as-is (value type)
+    public void TestPublicReferenceTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "PublicRefTypeField";
+        const string value = "test";
+
+        InstanceSetter<object, string> setter = Accessor.GenerateInstanceSetter<string>(typeof(SampleClass), fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, instance.PublicRefTypeField);
+    }
+
+    [TestMethod]
+    // field: public, non-readonly, reference type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as a boxed value type
+    public void TestPublicObjectReferenceTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "PublicRefTypeField";
+        const string value = "test";
+
+        InstanceSetter<object, object> setter = Accessor.GenerateInstanceSetter<object>(typeof(SampleClass), fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, instance.PublicRefTypeField);
+    }
+
+    /*
+     * Private reference type field in value type
+     */
+
+    [TestMethod]
+    // field: private, non-readonly, reference type
+    // instance: value type
+    // instance: passed as-is (value type)
+    // value: passed as-is (value type)
+    public void TestPrivateReferenceTypeFieldInValueType()
+    {
+        const string fieldName = "_privateRefTypeField";
+
+        Assert.ThrowsException<Exception>(() =>
+        {
+            _ = Accessor.GenerateInstanceSetter<SampleStruct, object>(fieldName, throwOnError: true)!;
+        }, "Does not throw exceptions for setting value types.");
+    }
+
+    [TestMethod]
+    // field: private, non-readonly, reference type
+    // instance: value type
+    // instance: passed as-is (value type)
+    // value: passed as a boxed value type
+    public void TestPrivateObjectReferenceTypeFieldInValueType()
+    {
+        const string fieldName = "_privateRefTypeField";
+
+        Assert.ThrowsException<Exception>(() =>
+        {
+            _ = Accessor.GenerateInstanceSetter<SampleStruct, object>(fieldName, throwOnError: true)!;
+        }, "Does not throw exceptions for setting value types.");
+    }
+
+    [TestMethod]
+    // field: private, non-readonly, reference type
+    // instance: value type
+    // instance: passed as a boxed value type
+    // value: passed as-is (value type)
+    public void TestPrivateReferenceTypeFieldInObjectValueType()
+    {
+        const string fieldName = "_privateRefTypeField";
+        const string value = "test";
+
+        InstanceSetter<object, string> setter = Accessor.GenerateInstanceSetter<string>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStruct).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(setter);
+
+        object instance = new SampleStruct();
+        setter(instance, value);
+
+        Assert.AreEqual(value, field.GetValue(instance));
+    }
+
+    [TestMethod]
+    // field: private, non-readonly, reference type
+    // instance: value type
+    // instance: passed as a boxed value type
+    // value: passed as a boxed value type
+    public void TestPrivateObjectReferenceTypeFieldInObjectValueType()
+    {
+        const string fieldName = "_privateRefTypeField";
+        const string value = "test";
+
+        InstanceSetter<object, object> setter = Accessor.GenerateInstanceSetter<object>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStruct).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(setter);
+
+        object instance = new SampleStruct();
+        setter(instance, value);
+
+        Assert.AreEqual(value, field.GetValue(instance));
+    }
+
+    /*
+     * Public reference type field in value type
+     */
+
+    [TestMethod]
+    // field: public, non-readonly, reference type
+    // instance: value type
+    // instance: passed as-is
+    // value: passed as-is (value type)
+    public void TestPublicReferenceTypeFieldInValueType()
+    {
+        const string fieldName = "PublicRefTypeField";
+
+        Assert.ThrowsException<Exception>(() =>
+        {
+            _ = Accessor.GenerateInstanceSetter<SampleStruct, object>(fieldName, throwOnError: true)!;
+        }, "Does not throw exceptions for setting value types.");
+    }
+
+    [TestMethod]
+    // field: public, non-readonly, reference type
+    // instance: value type
+    // instance: passed as-is
+    // value: passed as a boxed value type
+    public void TestPublicObjectReferenceTypeFieldInValueType()
+    {
+        const string fieldName = "PublicRefTypeField";
+
+        Assert.ThrowsException<Exception>(() =>
+        {
+            _ = Accessor.GenerateInstanceSetter<SampleStruct, object>(fieldName, throwOnError: true)!;
+        }, "Does not throw exceptions for setting value types.");
+    }
+
+    [TestMethod]
+    // field: public, non-readonly, reference type
+    // instance: value type
+    // instance: passed as an object
+    // value: passed as-is (value type)
+    public void TestPublicReferenceTypeFieldInObjectValueType()
+    {
+        const string fieldName = "PublicRefTypeField";
+        const string value = "test";
+
+        InstanceSetter<object, string> setter = Accessor.GenerateInstanceSetter<string>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(setter);
+
+        object instance = new SampleStruct();
+        setter(instance, value);
+
+        Assert.AreEqual(value, ((SampleStruct)instance).PublicRefTypeField);
+    }
+
+    [TestMethod]
+    // field: public, non-readonly, reference type
+    // instance: value type
+    // instance: passed as an object
+    // value: passed as a boxed value type
+    public void TestPublicObjectReferenceTypeFieldInObjectValueType()
+    {
+        const string fieldName = "PublicRefTypeField";
+        const string value = "test";
+
+        InstanceSetter<object, object> setter = Accessor.GenerateInstanceSetter<object>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(setter);
+
+        object instance = new SampleStruct();
+        setter(instance, value);
+
+        Assert.AreEqual(value, ((SampleStruct)instance).PublicRefTypeField);
+    }
+
+    /*
+     * Private readonly value type field in reference type
+     */
+
+    [TestMethod]
+    // field: private, readonly, value type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as-is (value type)
+    public void TestReadonlyPrivateValueTypeFieldInReferenceType()
+    {
+        const string fieldName = "_privateReadonlyValTypeField";
+        const int value = 1;
+
+        InstanceSetter<SampleClass, int> setter = Accessor.GenerateInstanceSetter<SampleClass, int>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, (int)field.GetValue(instance));
+    }
+
+    [TestMethod]
+    // field: private, readonly, value type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as a boxed value type
+    public void TestReadonlyPrivateBoxedValueTypeFieldInReferenceType()
+    {
+        const string fieldName = "_privateReadonlyValTypeField";
+        const int value = 1;
+
+        InstanceSetter<SampleClass, object> setter = Accessor.GenerateInstanceSetter<SampleClass, object>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, (int)field.GetValue(instance));
+    }
+
+    [TestMethod]
+    // field: private, readonly, value type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as-is (value type)
+    public void TestReadonlyPrivateValueTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "_privateReadonlyValTypeField";
+        const int value = 1;
+
+        InstanceSetter<object, int> setter = Accessor.GenerateInstanceSetter<int>(typeof(SampleClass), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, (int)field.GetValue(instance));
+    }
+
+    [TestMethod]
+    // field: private, readonly, value type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as a boxed value type
+    public void TestReadonlyPrivateBoxedValueTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "_privateReadonlyValTypeField";
+        const int value = 1;
+
+        InstanceSetter<object, object> setter = Accessor.GenerateInstanceSetter<object>(typeof(SampleClass), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, (int)field.GetValue(instance));
+    }
+
+    /*
+     * Public readonly value type field in reference type
+     */
+
+    [TestMethod]
+    // field: public, readonly, value type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as-is (value type)
+    public void TestReadonlyPublicValueTypeFieldInReferenceType()
+    {
+        const string fieldName = "PublicReadonlyValTypeField";
+        const int value = 1;
+
+        InstanceSetter<SampleClass, int> setter = Accessor.GenerateInstanceSetter<SampleClass, int>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, instance.PublicReadonlyValTypeField);
+    }
+
+    [TestMethod]
+    // field: public, readonly, value type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as a boxed value type
+    public void TestReadonlyPublicBoxedValueTypeFieldInReferenceType()
+    {
+        const string fieldName = "PublicReadonlyValTypeField";
+        const int value = 1;
+
+        InstanceSetter<SampleClass, object> setter = Accessor.GenerateInstanceSetter<SampleClass, object>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, instance.PublicReadonlyValTypeField);
+    }
+
+    [TestMethod]
+    // field: public, readonly, value type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as-is (value type)
+    public void TestReadonlyPublicValueTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "PublicReadonlyValTypeField";
+        const int value = 1;
+
+        InstanceSetter<object, int> setter = Accessor.GenerateInstanceSetter<int>(typeof(SampleClass), fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, instance.PublicReadonlyValTypeField);
+    }
+
+    [TestMethod]
+    // field: public, readonly, value type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as a boxed value type
+    public void TestReadonlyPublicBoxedValueTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "PublicReadonlyValTypeField";
+        const int value = 1;
+
+        InstanceSetter<object, object> setter = Accessor.GenerateInstanceSetter<object>(typeof(SampleClass), fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, instance.PublicReadonlyValTypeField);
+    }
+
+    /*
+     * Private readonly value type field in value type
+     */
+
+    [TestMethod]
+    // field: private, readonly, value type
+    // instance: value type
+    // instance: passed as-is (value type)
+    // value: passed as-is (value type)
+    public void TestReadonlyPrivateValueTypeFieldInValueType()
+    {
+        const string fieldName = "_privateReadonlyValTypeField";
+
+        Assert.ThrowsException<Exception>(() =>
+        {
+            _ = Accessor.GenerateInstanceSetter<SampleStruct, int>(fieldName, throwOnError: true)!;
+        }, "Does not throw exceptions for setting value types.");
+    }
+
+    [TestMethod]
+    // field: private, readonly, value type
+    // instance: value type
+    // instance: passed as-is (value type)
+    // value: passed as a boxed value type
+    public void TestReadonlyPrivateBoxedValueTypeFieldInValueType()
+    {
+        const string fieldName = "_privateReadonlyValTypeField";
+
+        Assert.ThrowsException<Exception>(() =>
+        {
+            _ = Accessor.GenerateInstanceSetter<SampleStruct, int>(fieldName, throwOnError: true)!;
+        }, "Does not throw exceptions for setting value types.");
+    }
+
+    [TestMethod]
+    // field: private, readonly, value type
+    // instance: value type
+    // instance: passed as a boxed value type
+    // value: passed as-is (value type)
+    public void TestReadonlyPrivateValueTypeFieldInObjectValueType()
+    {
+        const string fieldName = "_privateReadonlyValTypeField";
+        const int value = 1;
+
+        InstanceSetter<object, int> setter = Accessor.GenerateInstanceSetter<int>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStruct).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(setter);
+
+        object instance = new SampleStruct();
+        setter(instance, value);
+
+        Assert.AreEqual(value, field.GetValue(instance));
+    }
+
+    [TestMethod]
+    // field: private, readonly, value type
+    // instance: value type
+    // instance: passed as a boxed value type
+    // value: passed as a boxed value type
+    public void TestReadonlyPrivateBoxedValueTypeFieldInObjectValueType()
+    {
+        const string fieldName = "_privateReadonlyValTypeField";
+        const int value = 1;
+
+        InstanceSetter<object, object> setter = Accessor.GenerateInstanceSetter<object>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStruct).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(setter);
+
+        object instance = new SampleStruct();
+        setter(instance, value);
+
+        Assert.AreEqual(value, (int)field.GetValue(instance));
+    }
+
+    /*
+     * Public readonly value type field in value type
+     */
+
+    [TestMethod]
+    // field: public, readonly, value type
+    // instance: value type
+    // instance: passed as-is
+    // value: passed as-is (value type)
+    public void TestReadonlyPublicValueTypeFieldInValueType()
+    {
+        const string fieldName = "PublicReadonlyValTypeField";
+
+        Assert.ThrowsException<Exception>(() =>
+        {
+            _ = Accessor.GenerateInstanceSetter<SampleStruct, int>(fieldName, throwOnError: true)!;
+        }, "Does not throw exceptions for setting value types.");
+    }
+
+    [TestMethod]
+    // field: public, readonly, value type
+    // instance: value type
+    // instance: passed as-is
+    // value: passed as a boxed value type
+    public void TestReadonlyPublicBoxedValueTypeFieldInValueType()
+    {
+        const string fieldName = "PublicReadonlyValTypeField";
+
+        Assert.ThrowsException<Exception>(() =>
+        {
+            _ = Accessor.GenerateInstanceSetter<SampleStruct, int>(fieldName, throwOnError: true)!;
+        }, "Does not throw exceptions for setting value types.");
+    }
+
+    [TestMethod]
+    // field: public, readonly, value type
+    // instance: value type
+    // instance: passed as an object
+    // value: passed as-is (value type)
+    public void TestReadonlyPublicValueTypeFieldInObjectValueType()
+    {
+        const string fieldName = "PublicReadonlyValTypeField";
+        const int value = 1;
+
+        InstanceSetter<object, int> setter = Accessor.GenerateInstanceSetter<int>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(setter);
+
+        object instance = new SampleStruct();
+        setter(instance, value);
+
+        Assert.AreEqual(value, ((SampleStruct)instance).PublicReadonlyValTypeField);
+    }
+
+    [TestMethod]
+    // field: public, readonly, value type
+    // instance: value type
+    // instance: passed as an object
+    // value: passed as a boxed value type
+    public void TestReadonlyPublicBoxedValueTypeFieldInObjectValueType()
+    {
+        const string fieldName = "PublicReadonlyValTypeField";
+        const int value = 1;
+
+        InstanceSetter<object, object> setter = Accessor.GenerateInstanceSetter<object>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(setter);
+
+        object instance = new SampleStruct();
+        setter(instance, value);
+
+        Assert.AreEqual(value, ((SampleStruct)instance).PublicReadonlyValTypeField);
+    }
+
+    /*
+     * Private readonly reference type field in reference type
+     */
+
+    [TestMethod]
+    // field: private, readonly, reference type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as-is (value type)
+    public void TestReadonlyPrivateReferenceTypeFieldInReferenceType()
+    {
+        const string fieldName = "_privateReadonlyRefTypeField";
+        const string value = "test";
+
+        InstanceSetter<SampleClass, string> setter = Accessor.GenerateInstanceSetter<SampleClass, string>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, field.GetValue(instance));
+    }
+
+    [TestMethod]
+    // field: private, readonly, reference type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as a boxed value type
+    public void TestReadonlyPrivateObjectReferenceTypeFieldInReferenceType()
+    {
+        const string fieldName = "_privateReadonlyRefTypeField";
+        const string value = "test";
+
+        InstanceSetter<SampleClass, object> setter = Accessor.GenerateInstanceSetter<SampleClass, object>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, (string)field.GetValue(instance));
+    }
+
+    [TestMethod]
+    // field: private, readonly, reference type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as-is (value type)
+    public void TestReadonlyPrivateReferenceTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "_privateReadonlyRefTypeField";
+        const string value = "test";
+
+        InstanceSetter<object, string> setter = Accessor.GenerateInstanceSetter<string>(typeof(SampleClass), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, field.GetValue(instance));
+    }
+
+    [TestMethod]
+    // field: private, readonly, reference type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as a boxed value type
+    public void TestReadonlyPrivateObjectReferenceTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "_privateReadonlyRefTypeField";
+        const string value = "test";
+
+        InstanceSetter<object, object> setter = Accessor.GenerateInstanceSetter<object>(typeof(SampleClass), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleClass).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, (string)field.GetValue(instance));
+    }
+
+    /*
+     * Public readonly reference type field in reference type
+     */
+
+    [TestMethod]
+    // field: public, readonly, reference type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as-is (value type)
+    public void TestReadonlyPublicReferenceTypeFieldInReferenceType()
+    {
+        const string fieldName = "PublicReadonlyRefTypeField";
+        const string value = "test";
+
+        InstanceSetter<SampleClass, string> setter = Accessor.GenerateInstanceSetter<SampleClass, string>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, instance.PublicReadonlyRefTypeField);
+    }
+
+    [TestMethod]
+    // field: public, readonly, reference type
+    // instance: reference type
+    // instance: passed as-is
+    // value: passed as a boxed value type
+    public void TestReadonlyPublicObjectReferenceTypeFieldInReferenceType()
+    {
+        const string fieldName = "PublicReadonlyRefTypeField";
+        const string value = "test";
+
+        InstanceSetter<SampleClass, object> setter = Accessor.GenerateInstanceSetter<SampleClass, object>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, instance.PublicReadonlyRefTypeField);
+    }
+
+    [TestMethod]
+    // field: public, readonly, reference type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as-is (value type)
+    public void TestReadonlyPublicReferenceTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "PublicReadonlyRefTypeField";
+        const string value = "test";
+
+        InstanceSetter<object, string> setter = Accessor.GenerateInstanceSetter<string>(typeof(SampleClass), fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, instance.PublicReadonlyRefTypeField);
+    }
+
+    [TestMethod]
+    // field: public, readonly, reference type
+    // instance: reference type
+    // instance: passed as an object
+    // value: passed as a boxed value type
+    public void TestReadonlyPublicObjectReferenceTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "PublicReadonlyRefTypeField";
+        const string value = "test";
+
+        InstanceSetter<object, object> setter = Accessor.GenerateInstanceSetter<object>(typeof(SampleClass), fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(setter);
+
+        SampleClass instance = new SampleClass();
+        setter(instance, value);
+
+        Assert.AreEqual(value, instance.PublicReadonlyRefTypeField);
+    }
+
+    /*
+     * Private readonly reference type field in value type
+     */
+
+    [TestMethod]
+    // field: private, readonly, reference type
+    // instance: value type
+    // instance: passed as-is (value type)
+    // value: passed as-is (value type)
+    public void TestReadonlyPrivateReferenceTypeFieldInValueType()
+    {
+        const string fieldName = "_privateReadonlyRefTypeField";
+
+        Assert.ThrowsException<Exception>(() =>
+        {
+            _ = Accessor.GenerateInstanceSetter<SampleStruct, int>(fieldName, throwOnError: true)!;
+        }, "Does not throw exceptions for setting value types.");
+    }
+
+    [TestMethod]
+    // field: private, readonly, reference type
+    // instance: value type
+    // instance: passed as-is (value type)
+    // value: passed as a boxed value type
+    public void TestReadonlyPrivateObjectReferenceTypeFieldInValueType()
+    {
+        const string fieldName = "_privateReadonlyRefTypeField";
+
+        Assert.ThrowsException<Exception>(() =>
+        {
+            _ = Accessor.GenerateInstanceSetter<SampleStruct, int>(fieldName, throwOnError: true)!;
+        }, "Does not throw exceptions for setting value types.");
+    }
+
+    [TestMethod]
+    // field: private, readonly, reference type
+    // instance: value type
+    // instance: passed as a boxed value type
+    // value: passed as-is (value type)
+    public void TestReadonlyPrivateReferenceTypeFieldInObjectValueType()
+    {
+        const string fieldName = "_privateReadonlyRefTypeField";
+        const string value = "test";
+
+        InstanceSetter<object, string> setter = Accessor.GenerateInstanceSetter<string>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStruct).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(setter);
+
+        object instance = new SampleStruct();
+        setter(instance, value);
+
+        Assert.AreEqual(value, field.GetValue(instance));
+    }
+
+    [TestMethod]
+    // field: private, readonly, reference type
+    // instance: value type
+    // instance: passed as a boxed value type
+    // value: passed as a boxed value type
+    public void TestReadonlyPrivateObjectReferenceTypeFieldInObjectValueType()
+    {
+        const string fieldName = "_privateReadonlyRefTypeField";
+        const string value = "test";
+
+        InstanceSetter<object, object> setter = Accessor.GenerateInstanceSetter<object>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStruct).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.IsNotNull(setter);
+
+        object instance = new SampleStruct();
+        setter(instance, value);
+
+        Assert.AreEqual(value, (string)field.GetValue(instance));
+    }
+
+    /*
+     * Public readonly reference type field in value type
+     */
+
+    [TestMethod]
+    // field: public, readonly, reference type
+    // instance: value type
+    // instance: passed as-is
+    // value: passed as-is (value type)
+    public void TestReadonlyPublicReferenceTypeFieldInValueType()
+    {
+        const string fieldName = "PublicReadonlyRefTypeField";
+
+        Assert.ThrowsException<Exception>(() =>
+        {
+            _ = Accessor.GenerateInstanceSetter<SampleStruct, int>(fieldName, throwOnError: true)!;
+        }, "Does not throw exceptions for setting value types.");
+    }
+
+    [TestMethod]
+    // field: public, readonly, reference type
+    // instance: value type
+    // instance: passed as-is
+    // value: passed as a boxed value type
+    public void TestReadonlyPublicObjectReferenceTypeFieldInValueType()
+    {
+        const string fieldName = "PublicReadonlyRefTypeField";
+
+        Assert.ThrowsException<Exception>(() =>
+        {
+            _ = Accessor.GenerateInstanceSetter<SampleStruct, int>(fieldName, throwOnError: true)!;
+        }, "Does not throw exceptions for setting value types.");
+    }
+
+    [TestMethod]
+    // field: public, readonly, reference type
+    // instance: value type
+    // instance: passed as an object
+    // value: passed as-is (value type)
+    public void TestReadonlyPublicReferenceTypeFieldInObjectValueType()
+    {
+        const string fieldName = "PublicReadonlyRefTypeField";
+        const string value = "test";
+
+        InstanceSetter<object, string> setter = Accessor.GenerateInstanceSetter<string>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(setter);
+
+        object instance = new SampleStruct();
+        setter(instance, value);
+
+        Assert.AreEqual(value, ((SampleStruct)instance).PublicReadonlyRefTypeField);
+    }
+
+    [TestMethod]
+    // field: public, readonly, reference type
+    // instance: value type
+    // instance: passed as an object
+    // value: passed as a boxed value type
+    public void TestReadonlyPublicObjectReferenceTypeFieldInObjectValueType()
+    {
+        const string fieldName = "PublicReadonlyRefTypeField";
+        const string value = "test";
+
+        InstanceSetter<object, object> setter = Accessor.GenerateInstanceSetter<object>(typeof(SampleStruct), fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(setter);
+
+        object instance = new SampleStruct();
+        setter(instance, value);
+
+        Assert.AreEqual(value, ((SampleStruct)instance).PublicReadonlyRefTypeField);
+    }
+}

--- a/ReflectionTools.Tests/Accessor_GeneratePropertyGetter.cs
+++ b/ReflectionTools.Tests/Accessor_GeneratePropertyGetter.cs
@@ -1,0 +1,60 @@
+﻿using DanielWillett.ReflectionTools.Tests.SampleObjects;
+
+namespace DanielWillett.ReflectionTools.Tests;
+
+[TestClass]
+[TestCategory("Accessor")]
+public class Accessor_GeneratePropertyGetter
+{
+    [TestMethod]
+    public void BasicInstanceGetter()
+    {
+        const string propertyName = "PublicValTypeProperty";
+        const int value = 3;
+
+        InstanceGetter<SampleClass, int> getter = Accessor.GenerateInstancePropertyGetter<SampleClass, int>(propertyName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+        SampleClass sampleClass = new SampleClass
+        {
+            PublicValTypeProperty = value
+        };
+
+        Assert.AreEqual(value, getter(sampleClass));
+    }
+    [TestMethod]
+    public void BasicInstanceNoGetterThrowsException()
+    {
+        const string propertyName = "PublicSetonlyValTypeProperty";
+
+        Assert.ThrowsException<Exception>(() =>
+        {
+            _ = Accessor.GenerateInstancePropertyGetter<SampleClass, int>(propertyName, throwOnError: true)!;
+        }, "Did not throw exception on missing getter.");
+    }
+    [TestMethod]
+    public void BasicStaticGetter()
+    {
+        const string propertyName = "PublicValTypeProperty";
+        const int value = 3;
+
+        StaticGetter<int> getter = Accessor.GenerateStaticPropertyGetter<SampleStaticMembers, int>(propertyName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+        SampleStaticMembers.PublicValTypeProperty = value;
+
+        Assert.AreEqual(value, getter());
+    }
+    [TestMethod]
+    public void BasicStaticNoGetterThrowsException()
+    {
+        const string propertyName = "PublicSetonlyValTypeProperty";
+
+        Assert.ThrowsException<Exception>(() =>
+        {
+            _ = Accessor.GenerateStaticPropertyGetter<SampleStaticMembers, int>(propertyName, throwOnError: true)!;
+        }, "Did not throw exception on missing getter.");
+    }
+}

--- a/ReflectionTools.Tests/Accessor_GeneratePropertySetter.cs
+++ b/ReflectionTools.Tests/Accessor_GeneratePropertySetter.cs
@@ -1,0 +1,59 @@
+﻿using DanielWillett.ReflectionTools.Tests.SampleObjects;
+
+namespace DanielWillett.ReflectionTools.Tests;
+
+[TestClass]
+[TestCategory("Accessor")]
+public class Accessor_GeneratePropertySetter
+{
+    [TestMethod]
+    public void BasicInstanceSetter()
+    {
+        const string propertyName = "PublicValTypeProperty";
+        const int value = 3;
+
+        InstanceSetter<SampleClass, int> setter = Accessor.GenerateInstancePropertySetter<SampleClass, int>(propertyName, throwOnError: true)!;
+        
+        Assert.IsNotNull(setter);
+
+        SampleClass sampleClass = new SampleClass();
+
+        setter(sampleClass, value);
+
+        Assert.AreEqual(value, sampleClass.PublicValTypeProperty);
+    }
+    [TestMethod]
+    public void BasicInstanceNoSetterThrowsException()
+    {
+        const string propertyName = "PublicGetonlyValTypeProperty";
+
+        Assert.ThrowsException<Exception>(() =>
+        {
+            _ = Accessor.GenerateInstancePropertySetter<SampleClass, int>(propertyName, throwOnError: true)!;
+        }, "Did not throw exception on missing setter.");
+    }
+    [TestMethod]
+    public void BasicStaticSetter()
+    {
+        const string propertyName = "PublicValTypeProperty";
+        const int value = 3;
+
+        StaticSetter<int> setter = Accessor.GenerateStaticPropertySetter<SampleStaticMembers, int>(propertyName, throwOnError: true)!;
+        
+        Assert.IsNotNull(setter);
+
+        setter(value);
+
+        Assert.AreEqual(value, SampleStaticMembers.PublicValTypeProperty);
+    }
+    [TestMethod]
+    public void BasicStaticNoSetterThrowsException()
+    {
+        const string propertyName = "PublicGetonlyValTypeProperty";
+
+        Assert.ThrowsException<Exception>(() =>
+        {
+            _ = Accessor.GenerateStaticPropertySetter<SampleStaticMembers, int>(propertyName, throwOnError: true)!;
+        }, "Did not throw exception on missing setter.");
+    }
+}

--- a/ReflectionTools.Tests/Accessor_GenerateStaticCaller.cs
+++ b/ReflectionTools.Tests/Accessor_GenerateStaticCaller.cs
@@ -1,0 +1,54 @@
+﻿using DanielWillett.ReflectionTools.Tests.SampleObjects;
+
+namespace DanielWillett.ReflectionTools.Tests;
+
+[TestClass]
+[TestCategory("Accessor")]
+public class Accessor_GenerateStaticCaller
+{
+    [TestMethod]
+    public void TestBasicDelegateAction()
+    {
+        const string methodName = "TestMethod";
+
+        using LogListener listener = new LogListener("Created basic delegate");
+
+        Action caller = Accessor.GenerateStaticCaller<SampleStaticMembers, Action>(methodName, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a basic delegate.");
+
+        Assert.ThrowsException<NotImplementedException>(() => caller(), "Method did not run.");
+    }
+    [TestMethod]
+    public void TestBasicDelegateActionPoppedReturnValue()
+    {
+        const string methodName = "TestMethodWithReturnValue";
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        Action caller = Accessor.GenerateStaticCaller<SampleStaticMembers, Action>(methodName, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        caller();
+    }
+    [TestMethod]
+    public void TestBasicDelegateActionGeneratedReturnValue()
+    {
+        const string methodName = "TestEmptyMethod";
+
+        using LogListener listener = new LogListener("Created dynamic method");
+
+        Func<string?> caller = Accessor.GenerateStaticCaller<SampleStaticMembers, Func<string?>>(methodName, throwOnError: true)!;
+
+        Assert.IsNotNull(caller);
+
+        Assert.IsTrue(listener.Result, "Method was not created with a dynamic method.");
+
+        Assert.AreEqual(null, caller(), "Method return value was not created.");
+    }
+}

--- a/ReflectionTools.Tests/Accessor_GenerateStaticGetter.cs
+++ b/ReflectionTools.Tests/Accessor_GenerateStaticGetter.cs
@@ -1,0 +1,373 @@
+﻿using DanielWillett.ReflectionTools.Tests.SampleObjects;
+using System.Reflection;
+
+namespace DanielWillett.ReflectionTools.Tests;
+
+[TestClass]
+[TestCategory("Accessor")]
+public class Accessor_GenerateStaticGetter
+{
+    /*
+     * Private value type
+     */
+
+    [TestMethod]
+    // field: private, non-readonly, value type
+    // value: passed as-is (value type)
+    public void TestPrivateValueTypeField()
+    {
+        const string fieldName = "PrivateValTypeField";
+        const int value = 1;
+
+        StaticGetter<int> getter = Accessor.GenerateStaticGetter<SampleStaticMembers, int>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStaticMembers).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        Assert.IsNotNull(getter);
+
+        field.SetValue(null, value);
+
+        Assert.AreEqual(value, getter());
+    }
+
+    [TestMethod]
+    // field: private, non-readonly, value type
+    // value: passed as boxed value type
+    public void TestPrivateBoxedValueTypeField()
+    {
+        const string fieldName = "PrivateValTypeField";
+        const int value = 1;
+
+        StaticGetter<object> getter = Accessor.GenerateStaticGetter<SampleStaticMembers, object>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStaticMembers).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        Assert.IsNotNull(getter);
+
+        field.SetValue(null, value);
+
+        Assert.AreEqual(value, (int)getter());
+    }
+
+    /*
+     * Private reference type
+     */
+
+    [TestMethod]
+    // field: private, non-readonly, value type
+    // value: passed as-is (value type)
+    public void TestPrivateReferenceTypeField()
+    {
+        const string fieldName = "PrivateRefTypeField";
+        const string value = "test";
+
+        StaticGetter<string> getter = Accessor.GenerateStaticGetter<SampleStaticMembers, string>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStaticMembers).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        Assert.IsNotNull(getter);
+
+        field.SetValue(null, value);
+
+        Assert.AreEqual(value, getter());
+    }
+
+    [TestMethod]
+    // field: private, non-readonly, value type
+    // value: passed as boxed value type
+    public void TestPrivateObjectReferenceTypeField()
+    {
+        const string fieldName = "PrivateRefTypeField";
+        const string value = "test";
+
+        StaticGetter<object> getter = Accessor.GenerateStaticGetter<SampleStaticMembers, object>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStaticMembers).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        Assert.IsNotNull(getter);
+
+        field.SetValue(null, value);
+
+        Assert.AreEqual(value, (string)getter());
+    }
+
+    /*
+     * Public value type
+     */
+
+    [TestMethod]
+    // field: public, non-readonly, value type
+    // value: passed as-is (value type)
+    public void TestPublicValueTypeField()
+    {
+        const string fieldName = "PublicValTypeField";
+        const int value = 1;
+
+        StaticGetter<int> getter = Accessor.GenerateStaticGetter<SampleStaticMembers, int>(fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(getter);
+
+        SampleStaticMembers.PublicValTypeField = value;
+
+        Assert.AreEqual(value, getter());
+    }
+
+    [TestMethod]
+    // field: public, non-readonly, value type
+    // value: passed as boxed value type
+    public void TestPublicBoxedValueTypeField()
+    {
+        const string fieldName = "PublicValTypeField";
+        const int value = 1;
+
+        StaticGetter<object> getter = Accessor.GenerateStaticGetter<SampleStaticMembers, object>(fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(getter);
+
+        SampleStaticMembers.PublicValTypeField = value;
+
+        Assert.AreEqual(value, (int)getter());
+    }
+
+    /*
+     * Public reference type
+     */
+
+    [TestMethod]
+    // field: public, non-readonly, value type
+    // value: passed as-is (value type)
+    public void TestPublicReferenceTypeField()
+    {
+        const string fieldName = "PublicRefTypeField";
+        const string value = "test";
+
+        StaticGetter<string> getter = Accessor.GenerateStaticGetter<SampleStaticMembers, string>(fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(getter);
+
+        SampleStaticMembers.PublicRefTypeField = value;
+
+        Assert.AreEqual(value, getter());
+    }
+
+    [TestMethod]
+    // field: public, non-readonly, value type
+    // value: passed as boxed value type
+    public void TestPublicObjectReferenceTypeField()
+    {
+        const string fieldName = "PublicRefTypeField";
+        const string value = "test";
+
+        StaticGetter<object> getter = Accessor.GenerateStaticGetter<SampleStaticMembers, object>(fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(getter);
+
+        SampleStaticMembers.PublicRefTypeField = value;
+
+        Assert.AreEqual(value, (string)getter());
+    }
+
+    /*
+     * Private readonly value type
+     */
+
+    [TestMethod]
+    // field: private, readonly, value type
+    // value: passed as-is (value type)
+    public void TestReadonlyPrivateValueTypeField()
+    {
+        const string fieldName = "PrivateReadonlyValTypeField";
+#if NET || NETCOREAPP
+        const int value = 0;
+#else
+        const int value = 1;
+#endif
+
+        StaticGetter<int> getter = Accessor.GenerateStaticGetter<SampleStaticMembers, int>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+#if !NET && !NETCOREAPP
+        FieldInfo field = typeof(SampleStaticMembers).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Static)!;
+        field.SetValue(null, value);
+#endif
+
+        Assert.AreEqual(value, getter());
+    }
+
+    [TestMethod]
+    // field: private, readonly, value type
+    // value: passed as boxed value type
+    public void TestReadonlyPrivateBoxedValueTypeField()
+    {
+        const string fieldName = "PrivateReadonlyValTypeField";
+#if NET || NETCOREAPP
+        const int value = 0;
+#else
+        const int value = 1;
+#endif
+
+        StaticGetter<object> getter = Accessor.GenerateStaticGetter<SampleStaticMembers, object>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+#if !NET && !NETCOREAPP
+        FieldInfo field = typeof(SampleStaticMembers).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Static)!;
+        field.SetValue(null, value);
+#endif
+
+        Assert.AreEqual(value, (int)getter());
+    }
+
+    /*
+     * Private readonly reference type
+     */
+
+    [TestMethod]
+    // field: private, readonly, value type
+    // value: passed as-is (value type)
+    public void TestReadonlyPrivateReferenceTypeField()
+    {
+        const string fieldName = "PrivateReadonlyRefTypeField";
+#if NET || NETCOREAPP
+        const string? value = null;
+#else
+        const string? value = "test";
+#endif
+
+        StaticGetter<string> getter = Accessor.GenerateStaticGetter<SampleStaticMembers, string>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+#if !NET && !NETCOREAPP
+        FieldInfo field = typeof(SampleStaticMembers).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Static)!;
+        field.SetValue(null, value);
+#endif
+
+        Assert.AreEqual(value, getter());
+    }
+
+    [TestMethod]
+    // field: private, readonly, value type
+    // value: passed as boxed value type
+    public void TestReadonlyPrivateObjectReferenceTypeField()
+    {
+        const string fieldName = "PrivateReadonlyRefTypeField";
+#if NET || NETCOREAPP
+        const string? value = null;
+#else
+        const string? value = "test";
+#endif
+
+        StaticGetter<object> getter = Accessor.GenerateStaticGetter<SampleStaticMembers, object>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+#if !NET && !NETCOREAPP
+        FieldInfo field = typeof(SampleStaticMembers).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Static)!;
+        field.SetValue(null, value);
+#endif
+
+        Assert.AreEqual(value, (string)getter());
+    }
+
+    /*
+     * Public readonly value type
+     */
+
+    [TestMethod]
+    // field: public, readonly, value type
+    // value: passed as-is (value type)
+    public void TestReadonlyPublicValueTypeField()
+    {
+        const string fieldName = "PublicReadonlyValTypeField";
+#if NET || NETCOREAPP
+        const int value = 0;
+#else
+        const int value = 1;
+#endif
+
+        StaticGetter<int> getter = Accessor.GenerateStaticGetter<SampleStaticMembers, int>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+#if !NET && !NETCOREAPP
+        FieldInfo field = typeof(SampleStaticMembers).GetField(fieldName, BindingFlags.Public | BindingFlags.Static)!;
+        field.SetValue(null, value);
+#endif
+
+        Assert.AreEqual(value, getter());
+    }
+
+    [TestMethod]
+    // field: public, readonly, value type
+    // value: passed as boxed value type
+    public void TestReadonlyPublicBoxedValueTypeField()
+    {
+        const string fieldName = "PublicReadonlyValTypeField";
+#if NET || NETCOREAPP
+        const int value = 0;
+#else
+        const int value = 1;
+#endif
+
+        StaticGetter<object> getter = Accessor.GenerateStaticGetter<SampleStaticMembers, object>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+#if !NET && !NETCOREAPP
+        FieldInfo field = typeof(SampleStaticMembers).GetField(fieldName, BindingFlags.Public | BindingFlags.Static)!;
+        field.SetValue(null, value);
+#endif
+
+        Assert.AreEqual(value, (int)getter());
+    }
+
+    /*
+     * Public readonly reference type
+     */
+
+    [TestMethod]
+    // field: public, readonly, value type
+    // value: passed as-is (value type)
+    public void TestReadonlyPublicReferenceTypeField()
+    {
+        const string fieldName = "PublicReadonlyRefTypeField";
+#if NET || NETCOREAPP
+        const string? value = null;
+#else
+        const string? value = "test";
+#endif
+
+        StaticGetter<string> getter = Accessor.GenerateStaticGetter<SampleStaticMembers, string>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+#if !NET && !NETCOREAPP
+        FieldInfo field = typeof(SampleStaticMembers).GetField(fieldName, BindingFlags.Public | BindingFlags.Static)!;
+        field.SetValue(null, value);
+#endif
+
+        Assert.AreEqual(value, getter());
+    }
+
+    [TestMethod]
+    // field: public, readonly, value type
+    // value: passed as boxed value type
+    public void TestReadonlyPublicObjectReferenceTypeField()
+    {
+        const string fieldName = "PublicReadonlyRefTypeField";
+#if NET || NETCOREAPP
+        const string? value = null;
+#else
+        const string? value = "test";
+#endif
+
+        StaticGetter<object> getter = Accessor.GenerateStaticGetter<SampleStaticMembers, object>(fieldName, throwOnError: true)!;
+        
+        Assert.IsNotNull(getter);
+
+#if !NET && !NETCOREAPP
+        FieldInfo field = typeof(SampleStaticMembers).GetField(fieldName, BindingFlags.Public | BindingFlags.Static)!;
+        field.SetValue(null, value);
+#endif
+
+        Assert.AreEqual(value, (string)getter());
+    }
+}

--- a/ReflectionTools.Tests/Accessor_GenerateStaticSetter.cs
+++ b/ReflectionTools.Tests/Accessor_GenerateStaticSetter.cs
@@ -1,0 +1,349 @@
+﻿using DanielWillett.ReflectionTools.Tests.SampleObjects;
+using System.Reflection;
+
+namespace DanielWillett.ReflectionTools.Tests;
+
+[TestClass]
+[TestCategory("Accessor")]
+public class Accessor_GenerateStaticSetter
+{
+    /*
+     * Private value type
+     */
+
+    [TestMethod]
+    // field: private, non-readonly, value type
+    // value: passed as-is (value type)
+    public void TestPrivateValueTypeField()
+    {
+        const string fieldName = "PrivateValTypeField";
+        const int value = 1;
+
+        StaticSetter<int> setter = Accessor.GenerateStaticSetter<SampleStaticMembers, int>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStaticMembers).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        Assert.IsNotNull(setter);
+
+        setter(value);
+
+        Assert.AreEqual(value, field.GetValue(null));
+    }
+
+    [TestMethod]
+    // field: private, non-readonly, value type
+    // value: passed as boxed value type
+    public void TestPrivateBoxedValueTypeField()
+    {
+        const string fieldName = "PrivateValTypeField";
+        const int value = 1;
+
+        StaticSetter<object> setter = Accessor.GenerateStaticSetter<SampleStaticMembers, object>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStaticMembers).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        Assert.IsNotNull(setter);
+
+        setter(value);
+
+        Assert.AreEqual(value, field.GetValue(null));
+    }
+
+    /*
+     * Private reference type
+     */
+
+    [TestMethod]
+    // field: private, non-readonly, value type
+    // value: passed as-is (value type)
+    public void TestPrivateReferenceTypeField()
+    {
+        const string fieldName = "PrivateRefTypeField";
+        const string value = "test";
+
+        StaticSetter<string> setter = Accessor.GenerateStaticSetter<SampleStaticMembers, string>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStaticMembers).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        Assert.IsNotNull(setter);
+        
+        setter(value);
+
+        Assert.AreEqual(value, field.GetValue(null));
+    }
+
+    [TestMethod]
+    // field: private, non-readonly, value type
+    // value: passed as boxed value type
+    public void TestPrivateObjectReferenceTypeField()
+    {
+        const string fieldName = "PrivateRefTypeField";
+        const string value = "test";
+
+        StaticSetter<object> setter = Accessor.GenerateStaticSetter<SampleStaticMembers, object>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStaticMembers).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        Assert.IsNotNull(setter);
+
+        setter(value);
+
+        Assert.AreEqual(value, field.GetValue(null));
+    }
+
+    /*
+     * Public value type
+     */
+
+    [TestMethod]
+    // field: public, non-readonly, value type
+    // value: passed as-is (value type)
+    public void TestPublicValueTypeField()
+    {
+        const string fieldName = "PublicValTypeField";
+        const int value = 1;
+
+        StaticSetter<int> setter = Accessor.GenerateStaticSetter<SampleStaticMembers, int>(fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(setter);
+
+        setter(value);
+
+        Assert.AreEqual(value, SampleStaticMembers.PublicValTypeField);
+    }
+
+    [TestMethod]
+    // field: public, non-readonly, value type
+    // value: passed as boxed value type
+    public void TestPublicBoxedValueTypeField()
+    {
+        const string fieldName = "PublicValTypeField";
+        const int value = 1;
+
+        StaticSetter<object> setter = Accessor.GenerateStaticSetter<SampleStaticMembers, object>(fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(setter);
+
+        setter(value);
+
+        Assert.AreEqual(value, SampleStaticMembers.PublicValTypeField);
+    }
+
+    /*
+     * Public reference type
+     */
+
+    [TestMethod]
+    // field: public, non-readonly, value type
+    // value: passed as-is (value type)
+    public void TestPublicReferenceTypeField()
+    {
+        const string fieldName = "PublicRefTypeField";
+        const string value = "test";
+
+        StaticSetter<string> setter = Accessor.GenerateStaticSetter<SampleStaticMembers, string>(fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(setter);
+
+        setter(value);
+
+        Assert.AreEqual(value, SampleStaticMembers.PublicRefTypeField);
+    }
+
+    [TestMethod]
+    // field: public, non-readonly, value type
+    // value: passed as boxed value type
+    public void TestPublicObjectReferenceTypeField()
+    {
+        const string fieldName = "PublicRefTypeField";
+        const string value = "test";
+
+        StaticSetter<object> setter = Accessor.GenerateStaticSetter<SampleStaticMembers, object>(fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(setter);
+
+        setter(value);
+
+        Assert.AreEqual(value, SampleStaticMembers.PublicRefTypeField);
+    }
+
+    /*
+     * Private readonly value type
+     */
+
+    [TestMethod]
+    // field: private, readonly, value type
+    // value: passed as-is (value type)
+    public void TestPrivateReadonlyValueTypeField()
+    {
+        const string fieldName = "PrivateReadonlyValTypeField";
+#if !NET && !NETCOREAPP
+        const int value = 1;
+
+        StaticSetter<int> setter = Accessor.GenerateStaticSetter<SampleStaticMembers, int>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStaticMembers).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        Assert.IsNotNull(setter);
+
+        setter(value);
+
+        Assert.AreEqual(value, field.GetValue(null));
+#else
+        Assert.ThrowsException<NotSupportedException>(() =>
+        {
+            _ = Accessor.GenerateStaticSetter<SampleStaticMembers, int>(fieldName, throwOnError: true)!;
+        }, "Didn't throw NotSupportedException for readonly static value type field.");
+#endif
+    }
+
+    [TestMethod]
+    // field: private, readonly, value type
+    // value: passed as boxed value type
+    public void TestPrivateReadonlyBoxedValueTypeField()
+    {
+        const string fieldName = "PrivateReadonlyValTypeField";
+#if !NET && !NETCOREAPP
+        const int value = 1;
+
+        StaticSetter<object> setter = Accessor.GenerateStaticSetter<SampleStaticMembers, object>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStaticMembers).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        Assert.IsNotNull(setter);
+
+        setter(value);
+
+        Assert.AreEqual(value, field.GetValue(null));
+#else
+        Assert.ThrowsException<NotSupportedException>(() =>
+        {
+            _ = Accessor.GenerateStaticSetter<SampleStaticMembers, object>(fieldName, throwOnError: true)!;
+        }, "Didn't throw NotSupportedException for readonly static value type field.");
+#endif
+    }
+
+    /*
+     * Private readonly reference type
+     */
+
+    [TestMethod]
+    // field: private, readonly, value type
+    // value: passed as-is (value type)
+    public void TestPrivateReadonlyReferenceTypeField()
+    {
+        const string fieldName = "PrivateReadonlyRefTypeField";
+        const string value = "test";
+
+        StaticSetter<string> setter = Accessor.GenerateStaticSetter<SampleStaticMembers, string>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStaticMembers).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        Assert.IsNotNull(setter);
+        
+        setter(value);
+
+        Assert.AreEqual(value, field.GetValue(null));
+    }
+
+    [TestMethod]
+    // field: private, readonly, value type
+    // value: passed as boxed value type
+    public void TestPrivateReadonlyObjectReferenceTypeField()
+    {
+        const string fieldName = "PrivateReadonlyRefTypeField";
+        const string value = "test";
+
+        StaticSetter<object> setter = Accessor.GenerateStaticSetter<SampleStaticMembers, object>(fieldName, throwOnError: true)!;
+        FieldInfo field = typeof(SampleStaticMembers).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        Assert.IsNotNull(setter);
+
+        setter(value);
+
+        Assert.AreEqual(value, field.GetValue(null));
+    }
+
+    /*
+     * Public readonly value type
+     */
+
+    [TestMethod]
+    // field: public, readonly, value type
+    // value: passed as-is (value type)
+    public void TestPublicReadonlyValueTypeField()
+    {
+        const string fieldName = "PublicReadonlyValTypeField";
+#if !NET && !NETCOREAPP
+        const int value = 1;
+
+        StaticSetter<int> setter = Accessor.GenerateStaticSetter<SampleStaticMembers, int>(fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(setter);
+
+        setter(value);
+
+        Assert.AreEqual(value, SampleStaticMembers.PublicReadonlyValTypeField);
+#else
+        Assert.ThrowsException<NotSupportedException>(() =>
+        {
+            _ = Accessor.GenerateStaticSetter<SampleStaticMembers, int>(fieldName, throwOnError: true)!;
+        }, "Didn't throw NotSupportedException for readonly static value type field.");
+#endif
+    }
+
+    [TestMethod]
+    // field: public, readonly, value type
+    // value: passed as boxed value type
+    public void TestPublicReadonlyBoxedValueTypeField()
+    {
+        const string fieldName = "PublicReadonlyValTypeField";
+#if !NET && !NETCOREAPP
+        const int value = 1;
+
+        StaticSetter<object> setter = Accessor.GenerateStaticSetter<SampleStaticMembers, object>(fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(setter);
+
+        setter(value);
+
+        Assert.AreEqual(value, SampleStaticMembers.PublicReadonlyValTypeField);
+#else
+        Assert.ThrowsException<NotSupportedException>(() =>
+        {
+            _ = Accessor.GenerateStaticSetter<SampleStaticMembers, object>(fieldName, throwOnError: true)!;
+        }, "Didn't throw NotSupportedException for readonly static value type field.");
+#endif
+    }
+
+    /*
+     * Public readonly reference type
+     */
+
+    [TestMethod]
+    // field: public, readonly, value type
+    // value: passed as-is (value type)
+    public void TestPublicReadonlyReferenceTypeField()
+    {
+        const string fieldName = "PublicReadonlyRefTypeField";
+        const string value = "test";
+
+        StaticSetter<string> setter = Accessor.GenerateStaticSetter<SampleStaticMembers, string>(fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(setter);
+
+        setter(value);
+
+        Assert.AreEqual(value, SampleStaticMembers.PublicReadonlyRefTypeField);
+    }
+
+    [TestMethod]
+    // field: public, readonly, value type
+    // value: passed as boxed value type
+    public void TestPublicReadonlyObjectReferenceTypeField()
+    {
+        const string fieldName = "PublicReadonlyRefTypeField";
+        const string value = "test";
+
+        StaticSetter<object> setter = Accessor.GenerateStaticSetter<SampleStaticMembers, object>(fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(setter);
+
+        setter(value);
+
+        Assert.AreEqual(value, SampleStaticMembers.PublicReadonlyRefTypeField);
+    }
+}

--- a/ReflectionTools.Tests/Accessor_SetterTypeChecking.cs
+++ b/ReflectionTools.Tests/Accessor_SetterTypeChecking.cs
@@ -1,0 +1,337 @@
+﻿using DanielWillett.ReflectionTools.Tests.SampleObjects;
+
+namespace DanielWillett.ReflectionTools.Tests;
+
+[TestClass]
+[TestCategory("Accessor")]
+public class Accessor_SetterTypeChecking
+{
+    [TestMethod]
+    public void CheckSetStaticValueTypeField()
+    {
+        const string fieldName = "PublicValTypeField";
+        const int value = 1;
+        
+        StaticSetter<object?> setter = Accessor.GenerateStaticSetter<SampleStaticMembers, object?>(fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(setter);
+
+        // does not throw exception
+        setter(value);
+
+        Assert.AreEqual(value, SampleStaticMembers.PublicValTypeField);
+
+        Assert.ThrowsException<NullReferenceException>(() =>
+        {
+            setter(null);
+        });
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            setter(new object());
+        });
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            setter(1u);
+        });
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            setter(3.0f);
+        });
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            setter(new SampleClass());
+        });
+    }
+
+    [TestMethod]
+    public void CheckSetStaticReferenceTypeField()
+    {
+        const string fieldName = "PublicBaseClassField";
+
+        StaticSetter<object?> setter = Accessor.GenerateStaticSetter<SampleStaticMembers, object?>(fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(setter);
+
+        // does not throw exception
+        setter(new SampleBaseClass());
+
+        Assert.AreEqual(typeof(SampleBaseClass), SampleStaticMembers.PublicBaseClassField.GetType());
+
+        // does not throw exception
+        setter(new SampleDerivingClass());
+
+        Assert.AreEqual(typeof(SampleDerivingClass), SampleStaticMembers.PublicBaseClassField.GetType());
+
+        // does not throw exception
+        setter(new SampleDoubleDerivingClass());
+
+        Assert.AreEqual(typeof(SampleDoubleDerivingClass), SampleStaticMembers.PublicBaseClassField.GetType());
+
+        // does not throw exception
+        setter(null);
+
+        Assert.IsNull(SampleStaticMembers.PublicBaseClassField);
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            setter(new object());
+        });
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            setter(1u);
+        });
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            setter(3.0f);
+        });
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            setter(new SampleClass());
+        });
+    }
+    [TestMethod]
+    public void CheckSetInstanceValueTypeFieldInReferenceType()
+    {
+        const string fieldName = "PublicValTypeField";
+        const int value = 1;
+
+        InstanceSetter<SampleClass, object?> setter = Accessor.GenerateInstanceSetter<SampleClass, object?>(fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(setter);
+
+        SampleClass sampleClass = new SampleClass();
+
+        // does not throw exception
+        setter(sampleClass, value);
+
+        Assert.AreEqual(value, sampleClass.PublicValTypeField);
+
+        Assert.ThrowsException<NullReferenceException>(() =>
+        {
+            setter(sampleClass, null);
+        });
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            setter(sampleClass, new object());
+        });
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            setter(sampleClass, 1u);
+        });
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            setter(sampleClass, 3.0f);
+        });
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            setter(sampleClass, new SampleClass());
+        });
+
+        Assert.ThrowsException<NullReferenceException>(() =>
+        {
+            setter(null!, value);
+        });
+    }
+
+    [TestMethod]
+    public void CheckSetInstanceReferenceTypeFieldInReferenceType()
+    {
+        const string fieldName = "PublicBaseClassField";
+
+        InstanceSetter<SampleClass, object?> setter = Accessor.GenerateInstanceSetter<SampleClass, object?>(fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(setter);
+
+        SampleClass sampleClass = new SampleClass();
+
+        // does not throw exception
+        setter(sampleClass, new SampleBaseClass());
+
+        Assert.AreEqual(typeof(SampleBaseClass), sampleClass.PublicBaseClassField.GetType());
+
+        // does not throw exception
+        setter(sampleClass, new SampleDerivingClass());
+
+        Assert.AreEqual(typeof(SampleDerivingClass), sampleClass.PublicBaseClassField.GetType());
+
+        // does not throw exception
+        setter(sampleClass, new SampleDoubleDerivingClass());
+
+        Assert.AreEqual(typeof(SampleDoubleDerivingClass), sampleClass.PublicBaseClassField.GetType());
+
+        // does not throw exception
+        setter(sampleClass, null);
+
+        Assert.IsNull(sampleClass.PublicBaseClassField);
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            setter(sampleClass, new object());
+        });
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            setter(sampleClass, 1u);
+        });
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            setter(sampleClass, 3.0f);
+        });
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            setter(sampleClass, new SampleClass());
+        });
+
+        Assert.ThrowsException<NullReferenceException>(() =>
+        {
+            setter(null!, new SampleBaseClass());
+        });
+    }
+    [TestMethod]
+    public void CheckSetInstanceValueTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "PublicValTypeField";
+        const int value = 1;
+
+        InstanceSetter<object?, object?> setter = Accessor.GenerateInstanceSetter<object?>(typeof(SampleClass), fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(setter);
+
+        SampleClass sampleClass = new SampleClass();
+
+        // does not throw exception
+        setter(sampleClass, value);
+
+        Assert.AreEqual(value, sampleClass.PublicValTypeField);
+
+        Assert.ThrowsException<NullReferenceException>(() =>
+        {
+            setter(sampleClass, null);
+        });
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            setter(sampleClass, new object());
+        });
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            setter(sampleClass, 1u);
+        });
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            setter(sampleClass, 3.0f);
+        });
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            setter(sampleClass, new SampleClass());
+        });
+
+        Assert.ThrowsException<NullReferenceException>(() =>
+        {
+            setter(null!, value);
+        });
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            setter(3, value);
+        });
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            setter("test", value);
+        });
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            setter(new SampleBaseClass(), value);
+        });
+    }
+
+    [TestMethod]
+    public void CheckSetInstanceReferenceTypeFieldInObjectReferenceType()
+    {
+        const string fieldName = "PublicBaseClassField";
+
+        InstanceSetter<object?, object?> setter = Accessor.GenerateInstanceSetter<object?>(typeof(SampleClass), fieldName, throwOnError: true)!;
+
+        Assert.IsNotNull(setter);
+
+        SampleClass sampleClass = new SampleClass();
+
+        // does not throw exception
+        setter(sampleClass, new SampleBaseClass());
+
+        Assert.AreEqual(typeof(SampleBaseClass), sampleClass.PublicBaseClassField.GetType());
+
+        // does not throw exception
+        setter(sampleClass, new SampleDerivingClass());
+
+        Assert.AreEqual(typeof(SampleDerivingClass), sampleClass.PublicBaseClassField.GetType());
+
+        // does not throw exception
+        setter(sampleClass, new SampleDoubleDerivingClass());
+
+        Assert.AreEqual(typeof(SampleDoubleDerivingClass), sampleClass.PublicBaseClassField.GetType());
+
+        // does not throw exception
+        setter(sampleClass, null);
+
+        Assert.IsNull(sampleClass.PublicBaseClassField);
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            setter(sampleClass, new object());
+        });
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            setter(sampleClass, 1u);
+        });
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            setter(sampleClass, 3.0f);
+        });
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            setter(sampleClass, new SampleClass());
+        });
+
+        Assert.ThrowsException<NullReferenceException>(() =>
+        {
+            setter(null!, new SampleBaseClass());
+        });
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            setter(3, new SampleBaseClass());
+        });
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            setter("test", new SampleBaseClass());
+        });
+
+        Assert.ThrowsException<InvalidCastException>(() =>
+        {
+            setter(new SampleBaseClass(), new SampleBaseClass());
+        });
+    }
+}

--- a/ReflectionTools.Tests/GlobalUsings.cs
+++ b/ReflectionTools.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/ReflectionTools.Tests/ReflectionTools.Tests.csproj
+++ b/ReflectionTools.Tests/ReflectionTools.Tests.csproj
@@ -15,6 +15,7 @@
     <Version>1.0.0</Version>
     <AssemblyVersion>$(Version).0</AssemblyVersion>
     <FileVersion>$(Version).0</FileVersion>
+    <NoWarn>CS8618, CS0169, CS8600</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ReflectionTools.Tests/ReflectionTools.Tests.csproj
+++ b/ReflectionTools.Tests/ReflectionTools.Tests.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net461;net481;net471;net45;net6.0;net5.0;net7.0;net8.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+
+    <RootNamespace>DanielWillett.ReflectionTools.Tests</RootNamespace>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <Version>1.0.0</Version>
+    <AssemblyVersion>$(Version).0</AssemblyVersion>
+    <FileVersion>$(Version).0</FileVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0" />
+
+    <ProjectReference Include="..\ReflectionTools\ReflectionTools.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ReflectionTools.Tests/SampleObjects/SampleAbstractClass.cs
+++ b/ReflectionTools.Tests/SampleObjects/SampleAbstractClass.cs
@@ -1,0 +1,12 @@
+﻿namespace DanielWillett.ReflectionTools.Tests.SampleObjects;
+public abstract class SampleAbstractClass
+{
+    public virtual int SampleVirtualPropertyValType { get; set; } = 1;
+    public virtual string SampleVirtualPropertyRefType { get; set; } = "base";
+    public abstract int SampleAbstractPropertyValType { get; set; }
+    public abstract string SampleAbstractPropertyRefType { get; set; }
+    public virtual int SampleVirtualMethodValType() => 1;
+    public virtual string SampleVirtualMethodRefType() => "base";
+    public abstract int SampleAbstractMethodValType();
+    public abstract string SampleAbstractMethodRefType();
+}

--- a/ReflectionTools.Tests/SampleObjects/SampleAbstractDerivingClass.cs
+++ b/ReflectionTools.Tests/SampleObjects/SampleAbstractDerivingClass.cs
@@ -1,0 +1,12 @@
+﻿namespace DanielWillett.ReflectionTools.Tests.SampleObjects;
+public class SampleAbstractDerivingClass : SampleAbstractClass
+{
+    public override string SampleVirtualPropertyRefType { get; set; } = "override";
+    public override int SampleVirtualPropertyValType { get; set; } = 10;
+    public override string SampleAbstractPropertyRefType { get; set; } = "override";
+    public override int SampleAbstractPropertyValType { get; set; } = 10;
+    public override int SampleVirtualMethodValType() => 10;
+    public override string SampleVirtualMethodRefType() => "override";
+    public override int SampleAbstractMethodValType() => 10;
+    public override string SampleAbstractMethodRefType() => "override";
+}

--- a/ReflectionTools.Tests/SampleObjects/SampleBaseClass.cs
+++ b/ReflectionTools.Tests/SampleObjects/SampleBaseClass.cs
@@ -1,0 +1,4 @@
+﻿namespace DanielWillett.ReflectionTools.Tests.SampleObjects;
+public class SampleBaseClass
+{
+}

--- a/ReflectionTools.Tests/SampleObjects/SampleClass.cs
+++ b/ReflectionTools.Tests/SampleObjects/SampleClass.cs
@@ -1,4 +1,8 @@
-﻿namespace DanielWillett.ReflectionTools.Tests.SampleObjects;
+﻿// ReSharper disable UnassignedReadonlyField
+// ReSharper disable UnassignedGetOnlyAutoProperty
+// ReSharper disable UnusedAutoPropertyAccessor.Local
+namespace DanielWillett.ReflectionTools.Tests.SampleObjects;
+#pragma warning disable CS0169
 #nullable disable
 public class SampleClass
 {
@@ -74,4 +78,8 @@ public class SampleClass
         
     }
 }
+#pragma warning restore CS0169
 #nullable restore
+// ReSharper restore UnassignedReadonlyField
+// ReSharper restore UnassignedGetOnlyAutoProperty
+// ReSharper restore UnusedAutoPropertyAccessor.Local

--- a/ReflectionTools.Tests/SampleObjects/SampleClass.cs
+++ b/ReflectionTools.Tests/SampleObjects/SampleClass.cs
@@ -1,0 +1,77 @@
+﻿namespace DanielWillett.ReflectionTools.Tests.SampleObjects;
+#nullable disable
+public class SampleClass
+{
+    private int _privateValTypeField;
+    private readonly int _privateReadonlyValTypeField;
+
+    private string _privateRefTypeField;
+    private readonly string _privateReadonlyRefTypeField;
+
+    public string PublicRefTypeField;
+    public readonly string PublicReadonlyRefTypeField;
+
+    public int PublicValTypeField;
+    public readonly int PublicReadonlyValTypeField;
+
+    public int PublicValTypeProperty { get; set; }
+    public int PublicGetonlyValTypeProperty { get; }
+    public int PublicSetonlyValTypeProperty { set => _privateValTypeField = value; }
+
+    public string PublicRefTypeProperty { get; set; }
+    public string PublicGetonlyRefTypeProperty { get; }
+    public string PublicSetonlyRefTypeProperty { set => _privateRefTypeField = value; }
+
+    public SampleBaseClass PublicBaseClassField;
+
+    public SampleClass()
+    {
+
+    }
+    public SampleClass(int publicReadonlyValType, string publicReadonlyRefType)
+    {
+        PublicReadonlyRefTypeField = publicReadonlyRefType;
+        PublicReadonlyValTypeField = publicReadonlyValType;
+        
+        PublicGetonlyValTypeProperty = publicReadonlyValType;
+        PublicGetonlyRefTypeProperty = publicReadonlyRefType;
+    }
+
+    public void NotImplementedNoParams()
+    {
+        throw new NotImplementedException();
+    }
+    public void SetRefTypeField(string value)
+    {
+        PublicRefTypeField = value;
+    }
+    public void SetValTypeField(int value)
+    {
+        PublicValTypeField = value;
+    }
+    public void TestMethodWithRefVTParameter(int value, ref int refValue)
+    {
+        refValue = value;
+    }
+    public void TestMethodWithRefRTParameter(string value, ref string refValue)
+    {
+        refValue = value;
+    }
+    public void TestMethodWithOutVTParameter(int value, out int outValue)
+    {
+        outValue = value;
+    }
+    public void TestMethodWithOutRTParameter(string value, out string outValue)
+    {
+        outValue = value;
+    }
+    public void TestMethodWithInVTParameter(int value, in int outValue)
+    {
+
+    }
+    public void TestMethodWithInRTParameter(string value, in string outValue)
+    {
+        
+    }
+}
+#nullable restore

--- a/ReflectionTools.Tests/SampleObjects/SampleDerivingClass.cs
+++ b/ReflectionTools.Tests/SampleObjects/SampleDerivingClass.cs
@@ -1,0 +1,4 @@
+﻿namespace DanielWillett.ReflectionTools.Tests.SampleObjects;
+public class SampleDerivingClass : SampleBaseClass
+{
+}

--- a/ReflectionTools.Tests/SampleObjects/SampleDoubleDerivingClass.cs
+++ b/ReflectionTools.Tests/SampleObjects/SampleDoubleDerivingClass.cs
@@ -1,0 +1,4 @@
+﻿namespace DanielWillett.ReflectionTools.Tests.SampleObjects;
+public class SampleDoubleDerivingClass : SampleDerivingClass
+{
+}

--- a/ReflectionTools.Tests/SampleObjects/SampleRefStruct.cs
+++ b/ReflectionTools.Tests/SampleObjects/SampleRefStruct.cs
@@ -1,0 +1,9 @@
+﻿namespace DanielWillett.ReflectionTools.Tests.SampleObjects;
+public unsafe ref struct SampleRefStruct
+{
+    public int* StackValue { get; set; }
+    public SampleRefStruct(int* stackValue)
+    {
+        StackValue = stackValue;
+    }
+}

--- a/ReflectionTools.Tests/SampleObjects/SampleStaticMembers.cs
+++ b/ReflectionTools.Tests/SampleObjects/SampleStaticMembers.cs
@@ -1,0 +1,59 @@
+﻿namespace DanielWillett.ReflectionTools.Tests.SampleObjects;
+public class SampleStaticMembers
+{
+    public static int PublicValTypeField;
+    public static string PublicRefTypeField;
+    private static int PrivateValTypeField;
+    private static string PrivateRefTypeField;
+    
+    public static readonly int PublicReadonlyValTypeField;
+    public static readonly string PublicReadonlyRefTypeField;
+    private static readonly int PrivateReadonlyValTypeField;
+    private static readonly string PrivateReadonlyRefTypeField;
+
+    public static SampleBaseClass PublicBaseClassField;
+
+    public static int PublicValTypeProperty { get; set; }
+    public static int PublicGetonlyValTypeProperty { get; }
+    public static int PublicSetonlyValTypeProperty { set => PrivateValTypeField = value; }
+
+    public static string PublicRefTypeProperty { get; set; }
+    public static string PublicGetonlyRefTypeProperty { get; }
+    public static string PublicSetonlyRefTypeProperty { set => PrivateRefTypeField = value; }
+
+    public static void TestMethod()
+    {
+        throw new NotImplementedException();
+    }
+    public static void TestEmptyMethod()
+    {
+
+    }
+    public static int TestMethodWithReturnValue()
+    {
+        return 3;
+    }
+
+    public static void TestMethodWithRefVTParameter(int value, ref int refValue)
+    {
+        refValue = value;
+    }
+    public static void TestMethodWithRefRTParameter(string value, ref string refValue)
+    {
+        refValue = value;
+    }
+    public static void TestMethodWithOutVTParameter(int value, out int outValue)
+    {
+        outValue = value;
+    }
+    public static void TestMethodWithOutRTParameter(string value, out string outValue)
+    {
+        outValue = value;
+    }
+    public static void TestMethodWithInVTParameter(int value, in int outValue)
+    {
+    }
+    public static void TestMethodWithInRTParameter(string value, in string outValue)
+    {
+    }
+}

--- a/ReflectionTools.Tests/SampleObjects/SampleStruct.cs
+++ b/ReflectionTools.Tests/SampleObjects/SampleStruct.cs
@@ -1,0 +1,68 @@
+﻿// ReSharper disable UnassignedReadonlyField
+// ReSharper disable UnassignedGetOnlyAutoProperty
+// ReSharper disable UnusedAutoPropertyAccessor.Local
+
+using System.Globalization;
+
+#pragma warning disable CS0169
+#nullable disable
+
+namespace DanielWillett.ReflectionTools.Tests.SampleObjects;
+public struct SampleStruct
+{
+    private int _privateValTypeField;
+    private readonly int _privateReadonlyValTypeField;
+
+    private string _privateRefTypeField;
+    private readonly string _privateReadonlyRefTypeField;
+
+    public string PublicRefTypeField;
+    public readonly string PublicReadonlyRefTypeField;
+
+    public int PublicValTypeField;
+    public readonly int PublicReadonlyValTypeField;
+
+    public SampleStruct()
+    {
+        
+    }
+    public SampleStruct(int publicReadonlyValType, string publicReadonlyRefType)
+    {
+        PublicReadonlyRefTypeField = publicReadonlyRefType;
+        PublicReadonlyValTypeField = publicReadonlyValType;
+        
+        PublicReadonlyValTypeProperty = publicReadonlyValType;
+        PublicReadonlyRefTypeProperty = publicReadonlyRefType;
+    }
+
+    public int PublicValTypeProperty { get; set; }
+    public int PublicReadonlyValTypeProperty { get; }
+
+    public string PublicRefTypeProperty { get; set; }
+    public string PublicReadonlyRefTypeProperty { get; }
+
+    private int PrivateValTypeProperty { get; set; }
+    private int PrivateReadonlyValTypeProperty { get; }
+
+    private string PrivateRefTypeProperty { get; set; }
+    private string PrivateReadonlyRefTypeProperty { get; }
+
+    public readonly void NotImplementedNoParams()
+    {
+        throw new NotImplementedException();
+    }
+    public void SetRefTypeField(string value)
+    {
+        PublicRefTypeField = value;
+    }
+    public void SetValTypeField(int value)
+    {
+        PublicValTypeField = value;
+    }
+}
+
+// ReSharper restore UnassignedReadonlyField
+// ReSharper restore UnassignedGetOnlyAutoProperty
+// ReSharper restore UnusedAutoPropertyAccessor.Local
+#pragma warning restore CS0169
+#nullable restore

--- a/ReflectionTools.Tests/TestSetup.cs
+++ b/ReflectionTools.Tests/TestSetup.cs
@@ -1,0 +1,76 @@
+﻿namespace DanielWillett.ReflectionTools.Tests;
+[TestClass]
+public class TestSetup
+{
+    public static event Action<string>? OnLog;
+    [AssemblyInitialize]
+    public static void Setup(TestContext testContext)
+    {
+        Accessor.LogILTraceMessages = true;
+        Accessor.LogDebugMessages = true;
+        Accessor.LogInfoMessages = true;
+        Accessor.LogWarningMessages = true;
+        Accessor.LogErrorMessages = true;
+
+        Accessor.Logger = new Logger(testContext);
+    }
+    private class Logger : IReflectionToolsLogger
+    {
+        private readonly TestContext _ctx;
+        public Logger(TestContext ctx)
+        {
+            _ctx = ctx;
+        }
+        public void LogDebug(string source, string message)
+        {
+            OnLog?.Invoke(message);
+            _ctx.WriteLine("[DBG] [" + source + "] " + message);
+        }
+        public void LogInfo(string source, string message)
+        {
+            OnLog?.Invoke(message);
+            _ctx.WriteLine("[INF] [" + source + "] " + message);
+        }
+        public void LogWarning(string source, string message)
+        {
+            OnLog?.Invoke(message);
+            _ctx.WriteLine("[WRN] [" + source + "] " + message);
+        }
+        public void LogError(string source, Exception? ex, string? message)
+        {
+            if (message != null)
+            {
+                OnLog?.Invoke(message);
+                _ctx.WriteLine("[ERR] [" + source + "] " + message);
+            }
+            if (ex != null)
+                _ctx.WriteLine("[ERR] [" + source + "]" + Environment.NewLine + ex);
+        }
+    }
+}
+
+public class LogListener : IDisposable
+{
+    public string Text { get; set; }
+    public bool Result { get; private set; }
+    public LogListener(string text)
+    {
+        Text = text;
+        TestSetup.OnLog += OnLog;
+    }
+
+    private void OnLog(string message)
+    {
+        if (message.IndexOf(Text, StringComparison.InvariantCultureIgnoreCase) != -1)
+        {
+            Result = true;
+            TestSetup.OnLog -= OnLog;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (!Result)
+            TestSetup.OnLog -= OnLog;
+    }
+}

--- a/ReflectionTools.sln
+++ b/ReflectionTools.sln
@@ -3,7 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.8.34212.112
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReflectionTools", "ReflectionTools\ReflectionTools.csproj", "{E1A68501-E32B-4969-B0DC-2AD9215CAE69}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReflectionTools", "ReflectionTools\ReflectionTools.csproj", "{E1A68501-E32B-4969-B0DC-2AD9215CAE69}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReflectionTools.Tests", "ReflectionTools.Tests\ReflectionTools.Tests.csproj", "{99FC4AAA-AC2D-40CB-9061-E70E05270B06}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{E1A68501-E32B-4969-B0DC-2AD9215CAE69}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E1A68501-E32B-4969-B0DC-2AD9215CAE69}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E1A68501-E32B-4969-B0DC-2AD9215CAE69}.Release|Any CPU.Build.0 = Release|Any CPU
+		{99FC4AAA-AC2D-40CB-9061-E70E05270B06}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{99FC4AAA-AC2D-40CB-9061-E70E05270B06}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{99FC4AAA-AC2D-40CB-9061-E70E05270B06}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{99FC4AAA-AC2D-40CB-9061-E70E05270B06}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ReflectionTools/Accessor.cs
+++ b/ReflectionTools/Accessor.cs
@@ -120,7 +120,7 @@ public static class Accessor
                 throw new Exception($"Unable to create instance setter for {typeof(TInstance).FullName}.{fieldName}, you must pass structs ({typeof(TInstance).Name}) as a boxed object.");
 
             if (LogErrorMessages)
-                Logger.LogError(source, null, $"Unable to create instance setter for {typeof(TInstance).Name}.{fieldName}, you must pass structs ({typeof(TInstance).Name}) as a boxed object.");
+                Logger.LogError(source, null, $"Unable to create instance setter for {typeof(TInstance).FullName}.{fieldName}, you must pass structs ({typeof(TInstance).Name}) as a boxed object.");
             return null;
         }
 
@@ -131,7 +131,7 @@ public static class Accessor
             if (throwOnError)
                 throw new Exception($"Unable to find matching field: {typeof(TInstance).FullName}.{fieldName}.");
             if (LogErrorMessages)
-                Logger.LogError(source, null, $"Unable to find matching field {typeof(TInstance).Name}.{fieldName}.");
+                Logger.LogError(source, null, $"Unable to find matching field {typeof(TInstance).FullName}.{fieldName}.");
             return null;
         }
 
@@ -175,12 +175,11 @@ public static class Accessor
                 typeLbl = il.DefineLabel();
                 il.Emit(OpCodes.Isinst, field.FieldType);
                 il.Emit(OpCodes.Dup);
-                il.Emit(OpCodes.Brtrue, typeLbl.Value);
+                il.Emit(OpCodes.Brtrue_S, typeLbl.Value);
                 il.Emit(OpCodes.Pop);
                 il.Emit(OpCodes.Ldarg_1);
                 il.Emit(OpCodes.Dup);
-                il.Emit(OpCodes.Ldnull);
-                il.Emit(OpCodes.Beq_S, typeLbl.Value);
+                il.Emit(OpCodes.Brfalse_S, typeLbl.Value);
                 il.Emit(OpCodes.Pop);
                 il.Emit(OpCodes.Pop);
                 string errMsg = "Invalid argument type passed to setter for " + fieldName + ". Expected " + field.FieldType.FullName + ".";
@@ -230,9 +229,9 @@ public static class Accessor
         catch (Exception ex)
         {
             if (throwOnError)
-                throw new Exception($"Error generating instance getter for {field.DeclaringType!.Name}.{fieldName}.", ex);
+                throw new Exception($"Error generating instance getter for {field.DeclaringType!.FullName}.{fieldName}.", ex);
             if (LogErrorMessages)
-                Logger.LogError(source, ex, $"Error generating instance getter for {field.DeclaringType!.Name}.{fieldName}.");
+                Logger.LogError(source, ex, $"Error generating instance getter for {field.DeclaringType!.FullName}.{fieldName}.");
             return null;
         }
     }
@@ -256,7 +255,7 @@ public static class Accessor
             if (throwOnError)
                 throw new Exception($"Unable to find matching field: {typeof(TInstance).FullName}.{fieldName}.");
             if (LogErrorMessages)
-                Logger.LogError(source, null, $"Unable to find matching property {typeof(TInstance).Name}.{fieldName}.");
+                Logger.LogError(source, null, $"Unable to find matching property {typeof(TInstance).FullName}.{fieldName}.");
             return null;
         }
 
@@ -305,9 +304,9 @@ public static class Accessor
         catch (Exception ex)
         {
             if (throwOnError)
-                throw new Exception($"Error generating instance getter for {typeof(TInstance)}.{fieldName}.", ex);
+                throw new Exception($"Error generating instance getter for {typeof(TInstance).FullName}.{fieldName}.", ex);
             if (LogErrorMessages)
-                Logger.LogError(source, ex, $"Error generating instance getter for {typeof(TInstance)}.{fieldName}.");
+                Logger.LogError(source, ex, $"Error generating instance getter for {typeof(TInstance).FullName}.{fieldName}.");
             return null;
         }
     }
@@ -345,9 +344,12 @@ public static class Accessor
             if (throwOnError)
                 throw new Exception($"Unable to find matching field: {declaringType.FullName}.{fieldName}.");
             if (LogErrorMessages)
-                Logger.LogError(source, null, $"Unable to find matching property {declaringType.Name}.{fieldName}.");
+                Logger.LogError(source, null, $"Unable to find matching property {declaringType.FullName}.{fieldName}.");
             return null;
         }
+
+        fieldName = field.Name;
+
         try
         {
             CheckExceptionConstructors();
@@ -378,9 +380,8 @@ public static class Accessor
                 il.Emit(OpCodes.Brtrue_S, lbl);
                 if (!isValueType)
                     il.Emit(OpCodes.Pop);
-                il.Emit(OpCodes.Ldnull);
                 il.Emit(OpCodes.Ldarg_0);
-                il.Emit(OpCodes.Beq_S, lbl2);
+                il.Emit(OpCodes.Brfalse_S, lbl2);
 
                 string castError = $"Invalid instance type passed to getter for {fieldName}. Expected {declaringType.FullName}.";
                 if (CastExCtor != null)
@@ -456,12 +457,11 @@ public static class Accessor
                     typeLbl = il.DefineLabel();
                     il.Emit(OpCodes.Isinst, field.FieldType);
                     il.Emit(OpCodes.Dup);
-                    il.Emit(OpCodes.Brtrue, typeLbl.Value);
+                    il.Emit(OpCodes.Brtrue_S, typeLbl.Value);
                     il.Emit(OpCodes.Pop);
                     il.Emit(OpCodes.Ldarg_1);
                     il.Emit(OpCodes.Dup);
-                    il.Emit(OpCodes.Ldnull);
-                    il.Emit(OpCodes.Beq_S, typeLbl.Value);
+                    il.Emit(OpCodes.Brfalse_S, typeLbl.Value);
                     il.Emit(OpCodes.Pop);
                     il.Emit(OpCodes.Pop);
                     string errMsg = "Invalid argument type passed to setter for " + fieldName + ". Expected " + field.FieldType.FullName + ".";
@@ -522,12 +522,11 @@ public static class Accessor
                     typeLbl = il.DefineLabel();
                     il.Emit(OpCodes.Isinst, field.FieldType);
                     il.Emit(OpCodes.Dup);
-                    il.Emit(OpCodes.Brtrue, typeLbl.Value);
+                    il.Emit(OpCodes.Brtrue_S, typeLbl.Value);
                     il.Emit(OpCodes.Pop);
                     il.Emit(OpCodes.Ldarg_1);
                     il.Emit(OpCodes.Dup);
-                    il.Emit(OpCodes.Ldnull);
-                    il.Emit(OpCodes.Beq_S, typeLbl.Value);
+                    il.Emit(OpCodes.Brfalse_S, typeLbl.Value);
                     il.Emit(OpCodes.Pop);
                     il.Emit(OpCodes.Pop);
                     string errMsg = "Invalid argument type passed to setter for " + fieldName + ". Expected " + field.FieldType.FullName + ".";
@@ -576,9 +575,9 @@ public static class Accessor
         catch (Exception ex)
         {
             if (throwOnError)
-                throw new Exception($"Error generating instance setter for {declaringType.Name}.{fieldName}.", ex);
+                throw new Exception($"Error generating instance setter for {declaringType.FullName}.{fieldName}.", ex);
             if (LogErrorMessages)
-                Logger.LogError(source, ex, $"Error generating instance setter for {declaringType.Name}.{fieldName}.");
+                Logger.LogError(source, ex, $"Error generating instance setter for {declaringType.FullName}.{fieldName}.");
             return null;
         }
     }
@@ -610,9 +609,12 @@ public static class Accessor
             if (throwOnError)
                 throw new Exception($"Unable to find matching field: {declaringType.FullName}.{fieldName}.");
             if (LogErrorMessages)
-                Logger.LogError(source, null, $"Unable to find matching property {declaringType.Name}.{fieldName}.");
+                Logger.LogError(source, null, $"Unable to find matching property {declaringType.FullName}.{fieldName}.");
             return null;
         }
+
+        fieldName = field.Name;
+
         try
         {
             CheckExceptionConstructors();
@@ -636,11 +638,10 @@ public static class Accessor
                 Label lbl2 = il.DefineLabel();
                 il.Emit(OpCodes.Isinst, declaringType);
                 il.Emit(OpCodes.Dup);
-                il.Emit(OpCodes.Brtrue, lbl.Value);
+                il.Emit(OpCodes.Brtrue_S, lbl.Value);
                 il.Emit(OpCodes.Pop);
-                il.Emit(OpCodes.Ldnull);
                 il.Emit(OpCodes.Ldarg_0);
-                il.Emit(OpCodes.Beq_S, lbl2);
+                il.Emit(OpCodes.Brfalse_S, lbl2);
                 string castError = "Invalid instance type passed to getter for " + fieldName + ". Expected " + declaringType.FullName + ".";
                 if (CastExCtor != null)
                     il.Emit(OpCodes.Ldstr, castError);
@@ -718,9 +719,9 @@ public static class Accessor
         catch (Exception ex)
         {
             if (throwOnError)
-                throw new Exception($"Error generating instance getter for {declaringType.Name}.{fieldName}.", ex);
+                throw new Exception($"Error generating instance getter for {declaringType.FullName}.{fieldName}.", ex);
             if (LogErrorMessages)
-                Logger.LogError(source, ex, $"Error generating instance getter for {declaringType.Name}.{fieldName}.");
+                Logger.LogError(source, ex, $"Error generating instance getter for {declaringType.FullName}.{fieldName}.");
             return null;
         }
     }
@@ -742,7 +743,7 @@ public static class Accessor
                 throw new Exception($"Unable to create instance setter for {typeof(TInstance).FullName}.{propertyName}, you must pass structs ({typeof(TInstance).Name}) as a boxed object.");
 
             if (LogErrorMessages)
-                Logger.LogError("Accessor.GenerateInstancePropertySetter", null, $"Unable to create instance setter for {typeof(TInstance).Name}.{propertyName}, you must pass structs ({typeof(TInstance).Name}) as a boxed object.");
+                Logger.LogError("Accessor.GenerateInstancePropertySetter", null, $"Unable to create instance setter for {typeof(TInstance).FullName}.{propertyName}, you must pass structs ({typeof(TInstance).Name}) as a boxed object.");
             return null;
         }
 
@@ -758,7 +759,7 @@ public static class Accessor
                 if (throwOnError)
                     throw new Exception($"Unable to find matching property: {typeof(TInstance).FullName}.{propertyName} with a setter.");
                 if (LogErrorMessages)
-                    Logger.LogError("Accessor.GenerateInstancePropertySetter", null, $"Unable to find matching property {typeof(TInstance).Name}.{propertyName} with a setter.");
+                    Logger.LogError("Accessor.GenerateInstancePropertySetter", null, $"Unable to find matching property {typeof(TInstance).FullName}.{propertyName} with a setter.");
                 return null;
             }
         }
@@ -789,7 +790,7 @@ public static class Accessor
                 if (throwOnError)
                     throw new Exception($"Unable to find matching property: {typeof(TInstance).FullName}.{propertyName} with a getter.");
                 if (LogErrorMessages)
-                    Logger.LogError("Accessor.GenerateInstancePropertyGetter", null, $"Unable to find matching property {typeof(TInstance).Name}.{propertyName} with a getter.");
+                    Logger.LogError("Accessor.GenerateInstancePropertyGetter", null, $"Unable to find matching property {typeof(TInstance).FullName}.{propertyName} with a getter.");
                 return null;
             }
         }
@@ -837,7 +838,7 @@ public static class Accessor
                 if (throwOnError)
                     throw new Exception($"Unable to find matching property: {declaringType.FullName}.{propertyName} with a setter.");
                 if (LogErrorMessages)
-                    Logger.LogError("Accessor.GenerateInstancePropertySetter", null, $"Unable to find matching property {declaringType.Name}.{propertyName} with a setter.");
+                    Logger.LogError("Accessor.GenerateInstancePropertySetter", null, $"Unable to find matching property {declaringType.FullName}.{propertyName} with a setter.");
                 return null;
             }
         }
@@ -880,7 +881,7 @@ public static class Accessor
                 if (throwOnError)
                     throw new Exception($"Unable to find matching property: {declaringType.FullName}.{propertyName} with a getter.");
                 if (LogErrorMessages)
-                    Logger.LogError("Accessor.GenerateInstancePropertyGetter", null, $"Unable to find matching property {declaringType.Name}.{propertyName} with a getter.");
+                    Logger.LogError("Accessor.GenerateInstancePropertyGetter", null, $"Unable to find matching property {declaringType.FullName}.{propertyName} with a getter.");
                 return null;
             }
         }
@@ -939,7 +940,7 @@ public static class Accessor
             if (throwOnError)
                 throw new Exception($"Unable to find matching field: {declaringType.FullName}.{fieldName}.");
             if (LogErrorMessages)
-                Logger.LogError(source, null, $"Unable to find matching field {declaringType.Name}.{fieldName}.");
+                Logger.LogError(source, null, $"Unable to find matching field {declaringType.FullName}.{fieldName}.");
             return null;
         }
 
@@ -988,12 +989,11 @@ public static class Accessor
                 lbl = il.DefineLabel();
                 il.Emit(OpCodes.Isinst, field.FieldType);
                 il.Emit(OpCodes.Dup);
-                il.Emit(OpCodes.Brtrue, lbl.Value);
+                il.Emit(OpCodes.Brtrue_S, lbl.Value);
                 il.Emit(OpCodes.Pop);
                 il.Emit(OpCodes.Ldarg_0);
                 il.Emit(OpCodes.Dup);
-                il.Emit(OpCodes.Ldnull);
-                il.Emit(OpCodes.Beq_S, lbl.Value);
+                il.Emit(OpCodes.Brfalse_S, lbl.Value);
                 il.Emit(OpCodes.Pop);
                 string errMsg = "Invalid argument type passed to getter for " + fieldName + ". Expected " + field.FieldType.FullName + ".";
                 if (CastExCtor != null)
@@ -1040,9 +1040,9 @@ public static class Accessor
         catch (Exception ex)
         {
             if (throwOnError)
-                throw new Exception($"Error generating static setter for {declaringType.Name}.{fieldName}.", ex);
+                throw new Exception($"Error generating static setter for {declaringType.FullName}.{fieldName}.", ex);
             if (LogErrorMessages)
-                Logger.LogError(source, ex, $"Error generating static setter for {declaringType.Name}.{fieldName}.");
+                Logger.LogError(source, ex, $"Error generating static setter for {declaringType.FullName}.{fieldName}.");
             return null;
         }
     }
@@ -1074,9 +1074,12 @@ public static class Accessor
             if (throwOnError)
                 throw new Exception($"Unable to find matching field: {declaringType.FullName}.{fieldName}.");
             if (LogErrorMessages)
-                Logger.LogError(source, null, $"Unable to find matching property {declaringType.Name}.{fieldName}.");
+                Logger.LogError(source, null, $"Unable to find matching property {declaringType.FullName}.{fieldName}.");
             return null;
         }
+
+        fieldName = field.Name;
+
         try
         {
             GetDynamicMethodFlags(true, out MethodAttributes attr, out CallingConventions convention);
@@ -1113,9 +1116,9 @@ public static class Accessor
         catch (Exception ex)
         {
             if (throwOnError)
-                throw new Exception($"Error generating static getter for {declaringType.Name}.{fieldName}.", ex);
+                throw new Exception($"Error generating static getter for {declaringType.FullName}.{fieldName}.", ex);
             if (LogErrorMessages)
-                Logger.LogError(source, ex, $"Error generating static getter for {declaringType.Name}.{fieldName}.");
+                Logger.LogError(source, ex, $"Error generating static getter for {declaringType.FullName}.{fieldName}.");
             return null;
         }
     }
@@ -1130,7 +1133,23 @@ public static class Accessor
     /// <remarks>Will never return <see langword="null"/> if <paramref name="throwOnError"/> is <see langword="true"/>.</remarks>
     [Pure]
     public static StaticSetter<TValue>? GenerateStaticPropertySetter<TDeclaringType, TValue>(string propertyName, bool throwOnError = false)
-        => GenerateStaticPropertySetter<TValue>(typeof(TDeclaringType), propertyName, throwOnError, true);
+        => GenerateStaticPropertySetter<TValue>(typeof(TDeclaringType), propertyName, throwOnError, false);
+
+    /// <summary>
+    /// Generates a delegate or dynamic method that sets a static property value.
+    /// </summary>
+    /// <typeparam name="TDeclaringType">Declaring type of the property.</typeparam>
+    /// <typeparam name="TValue">Property return type.</typeparam>
+    /// <param name="propertyName">Name of property that will be referenced.</param>
+    /// <param name="throwOnError">Throw an error instead of writing to console and returning <see langword="null"/>.</param>
+    /// <param name="allowUnsafeTypeBinding">Enables unsafe type binding to non-matching delegates, meaning classes of different
+    /// types can be passed as parameters and an exception will not be thrown (may cause unintended behavior if the wrong type is passed).
+    /// This also must be <see langword="true"/> to not null-check instance methods of parameter-less reference types with a dynamic method.</param>
+    /// <remarks>Will never return <see langword="null"/> if <paramref name="throwOnError"/> is <see langword="true"/>.</remarks>
+    [Pure]
+    // ReSharper disable once MethodOverloadWithOptionalParameter
+    public static StaticSetter<TValue>? GenerateStaticPropertySetter<TDeclaringType, TValue>(string propertyName, bool throwOnError = false, bool allowUnsafeTypeBinding = false)
+        => GenerateStaticPropertySetter<TValue>(typeof(TDeclaringType), propertyName, throwOnError, allowUnsafeTypeBinding);
 
     /// <summary>
     /// Generates a delegate that gets a static property value.
@@ -1145,10 +1164,27 @@ public static class Accessor
         => GenerateStaticPropertyGetter<TValue>(typeof(TDeclaringType), propertyName, throwOnError, true);
 
     /// <summary>
+    /// Generates a delegate that gets a static property value.
+    /// </summary>
+    /// <typeparam name="TDeclaringType">Declaring type of the property.</typeparam>
+    /// <typeparam name="TValue">Property return type.</typeparam>
+    /// <param name="propertyName">Name of property that will be referenced.</param>
+    /// <param name="throwOnError">Throw an error instead of writing to console and returning <see langword="null"/>.</param>
+    /// <param name="allowUnsafeTypeBinding">Enables unsafe type binding to non-matching delegates, meaning classes of different
+    /// types can be passed as parameters and an exception will not be thrown (may cause unintended behavior if the wrong type is passed).
+    /// This also must be <see langword="true"/> to not null-check instance methods of parameter-less reference types with a dynamic method.</param>
+    /// <remarks>Will never return <see langword="null"/> if <paramref name="throwOnError"/> is <see langword="true"/>.</remarks>
+    [Pure]
+    // ReSharper disable once MethodOverloadWithOptionalParameter
+    public static StaticGetter<TValue>? GenerateStaticPropertyGetter<TDeclaringType, TValue>(string propertyName, bool throwOnError = false, bool allowUnsafeTypeBinding = true)
+        => GenerateStaticPropertyGetter<TValue>(typeof(TDeclaringType), propertyName, throwOnError, allowUnsafeTypeBinding);
+
+    /// <summary>
     /// Generates a delegate or dynamic method that sets a static property value.
     /// </summary>
     /// <param name="allowUnsafeTypeBinding">Enables unsafe type binding to non-matching delegates, meaning classes of different
-    /// types can be passed as parameters and an exception will not be thrown (may cause unintended behavior if the wrong type is passed).</param>
+    /// types can be passed as parameters and an exception will not be thrown (may cause unintended behavior if the wrong type is passed).
+    /// This also must be <see langword="true"/> to not null-check instance methods of parameter-less reference types with a dynamic method.</param>
     /// <param name="declaringType">Declaring type of the property.</param>
     /// <typeparam name="TValue">Property return type.</typeparam>
     /// <param name="propertyName">Name of property that will be referenced.</param>
@@ -1173,7 +1209,7 @@ public static class Accessor
             if (throwOnError)
                 throw new Exception($"Unable to find matching property: {declaringType.FullName}.{propertyName} with a setter.");
             if (LogErrorMessages)
-                Logger.LogError("Accessor.GenerateStaticPropertySetter", null, $"Unable to find matching property {declaringType.Name}.{propertyName} with a setter.");
+                Logger.LogError("Accessor.GenerateStaticPropertySetter", null, $"Unable to find matching property {declaringType.FullName}.{propertyName} with a setter.");
             return null;
         }
 
@@ -1184,7 +1220,8 @@ public static class Accessor
     /// Generates a delegate that gets a static property value.
     /// </summary>
     /// <param name="allowUnsafeTypeBinding">Enables unsafe type binding to non-matching delegates, meaning classes of different
-    /// types can be passed as parameters and an exception will not be thrown (may cause unintended behavior if the wrong type is passed).</param>
+    /// types can be passed as parameters and an exception will not be thrown (may cause unintended behavior if the wrong type is passed).
+    /// This also must be <see langword="true"/> to not null-check instance methods of parameter-less reference types with a dynamic method.</param>
     /// <param name="declaringType">Declaring type of the property.</param>
     /// <typeparam name="TValue">Property return type.</typeparam>
     /// <param name="propertyName">Name of property that will be referenced.</param>
@@ -1209,7 +1246,7 @@ public static class Accessor
             if (throwOnError)
                 throw new Exception($"Unable to find matching property: {declaringType.FullName}.{propertyName} with a getter.");
             if (LogErrorMessages)
-                Logger.LogError("Accessor.GenerateStaticPropertyGetter", null, $"Unable to find matching property {declaringType.Name}.{propertyName} with a getter.");
+                Logger.LogError("Accessor.GenerateStaticPropertyGetter", null, $"Unable to find matching property {declaringType.FullName}.{propertyName} with a getter.");
             return null;
         }
 
@@ -1258,7 +1295,7 @@ public static class Accessor
                     throw new Exception($"Unable to find matching instance method: {typeof(TInstance).FullName}.{methodName}.");
 
                 if (LogErrorMessages)
-                    Logger.LogError("Accessor.GenerateInstanceCaller", null, $"Unable to find matching instance method: {typeof(TInstance).Name}.{methodName}.");
+                    Logger.LogError("Accessor.GenerateInstanceCaller", null, $"Unable to find matching instance method: {typeof(TInstance).FullName}.{methodName}.");
                 return null;
             }
         }
@@ -1314,7 +1351,7 @@ public static class Accessor
                     throw new Exception($"Unable to find matching instance method: {typeof(TInstance).FullName}.{methodName}.");
 
                 if (LogErrorMessages)
-                    Logger.LogError("Accessor.GenerateInstanceCaller", null, $"Unable to find matching instance method: {typeof(TInstance).Name}.{methodName}.");
+                    Logger.LogError("Accessor.GenerateInstanceCaller", null, $"Unable to find matching instance method: {typeof(TInstance).FullName}.{methodName}.");
                 return null;
             }
         }
@@ -1356,7 +1393,7 @@ public static class Accessor
                 throw new ArgumentException($"Method {method.DeclaringType.FullName}.{method.Name} can not have more than {maxArgs} arguments!", nameof(method));
 
             if (LogErrorMessages)
-                Logger.LogError("Accessor.GenerateInstanceCaller", null, $"Method {method.DeclaringType.Name}.{method.Name} can not have more than {maxArgs} arguments!");
+                Logger.LogError("Accessor.GenerateInstanceCaller", null, $"Method {method.DeclaringType.FullName}.{method.Name} can not have more than {maxArgs} arguments!");
             return null;
         }
 
@@ -1413,9 +1450,9 @@ public static class Accessor
         ParameterInfo[] delegateParameters = invokeMethod.GetParameters();
         Type delegateReturnType = invokeMethod.ReturnType;
         bool shouldCallvirt = method.ShouldCallvirtRuntime();
-        bool needsDynamicMethod = shouldCallvirt || (!method.DeclaringType.IsValueType && !allowUnsafeTypeBinding) || method.ReturnType != typeof(void) && delegateReturnType == typeof(void);
+        bool needsDynamicMethod = shouldCallvirt || (!instance.IsValueType && !allowUnsafeTypeBinding) || method.ReturnType != typeof(void) && delegateReturnType == typeof(void);
         bool isInstanceForValueType = method is { DeclaringType.IsValueType: true };
-        shouldCallvirt |= !method.DeclaringType.IsValueType;
+        shouldCallvirt |= !instance.IsValueType;
 
         // for some reasons invoking a delegate with zero parameters and a null instance does not throw an exception.
         // Adding parameters changes this behavior.
@@ -1425,14 +1462,14 @@ public static class Accessor
         if (p.Length != delegateParameters.Length - 1)
         {
             if (throwOnError)
-                throw new Exception("Unable to create instance caller for " + (method.DeclaringType?.Name ?? "<unknown-type>") + "." + (method.Name ?? "<unknown-name>") + $": incompatable delegate type: {delegateType.Name}.");
+                throw new Exception("Unable to create instance caller for " + instance.FullName + "." + (method.Name ?? "<unknown-name>") + $": incompatable delegate type: {delegateType.FullName}.");
 
             if (LogErrorMessages)
-                Logger.LogError(source, null, $"Unable to create instance caller for {method}: incompatable delegate type: {delegateType.Name}.");
+                Logger.LogError(source, null, $"Unable to create instance caller for {instance.FullName}.{method.Name}: incompatable delegate type: {delegateType.FullName}.");
             return null;
         }
 
-        if (needsDynamicMethod && method.DeclaringType.IsInterface && !delegateParameters[0].ParameterType.IsInterface)
+        if (needsDynamicMethod && instance.IsInterface && !delegateParameters[0].ParameterType.IsInterface)
             needsDynamicMethod = false;
 
         // exact match
@@ -1453,14 +1490,14 @@ public static class Accessor
                 {
                     Delegate basicDelegate = method.CreateDelegate(delegateType);
                     if (LogDebugMessages || LogILTraceMessages)
-                        Logger.LogDebug(source, $"Created basic delegate binding instance caller for {method.DeclaringType.Name}.{method.Name}.");
+                        Logger.LogDebug(source, $"Created basic delegate binding instance caller for {instance.FullName}.{method.Name}.");
                     return basicDelegate;
                 }
                 catch (Exception ex)
                 {
                     if (LogDebugMessages || LogILTraceMessages)
                     {
-                        Logger.LogDebug(source, $"Unable to create basic delegate binding instance caller for {method.DeclaringType.Name}.{method.Name}.");
+                        Logger.LogDebug(source, $"Unable to create basic delegate binding instance caller for {instance.FullName}.{method.Name}.");
                         Logger.LogDebug(source, ex.GetType() + " - " + ex.Message);
                     }
                 }
@@ -1470,10 +1507,10 @@ public static class Accessor
         if (isInstanceForValueType && delegateParameters[0].ParameterType != typeof(object) && !method.IsReadOnly())
         {
             if (throwOnError)
-                throw new Exception($"Unable to create instance caller for {method.DeclaringType?.Name ?? "<unknown-type>"}.{method.Name ?? "<unknown-name>"} (non-readonly), you must pass structs ({instance.FullName}) as a boxed object (in {delegateType.FullName}).");
+                throw new Exception($"Unable to create instance caller for {instance.FullName}.{method.Name} (non-readonly), you must pass structs ({instance.Name}) as a boxed object (in {delegateType.FullName}).");
 
             if (LogErrorMessages || LogILTraceMessages)
-                Logger.LogError(source, null, $"Unable to create instance caller for {method} (non-readonly), you must pass structs ({instance.Name}) as a boxed object (in {delegateType.Name}).");
+                Logger.LogError(source, null, $"Unable to create instance caller for {instance.FullName}.{method.Name} (non-readonly), you must pass structs ({instance.Name}) as a boxed object (in {delegateType.FullName}).");
             return null;
         }
 
@@ -1500,14 +1537,14 @@ public static class Accessor
                     object d2 = FormatterServices.GetUninitializedObject(delegateType);
                     delegateType.GetConstructors()[0].Invoke(d2, new object[] { null!, ptr });
                     if (LogDebugMessages || LogILTraceMessages)
-                        Logger.LogDebug(source, $"Created unsafely binded delegate binding instance caller for {method.DeclaringType.Name}.{method.Name}.");
+                        Logger.LogDebug(source, $"Created unsafely binded delegate binding instance caller for {instance.Name}.{method.Name}.");
                     return (Delegate)d2;
                 }
                 catch (Exception ex)
                 {
                     if (LogDebugMessages || LogILTraceMessages)
                     {
-                        Logger.LogDebug(source, $"Unable to create unsafely binded delegate binding instance caller for {method.DeclaringType.Name}.{method.Name}.");
+                        Logger.LogDebug(source, $"Unable to create unsafely binded delegate binding instance caller for {instance.Name}.{method.Name}.");
                         Logger.LogDebug(source, ex.GetType() + " - " + ex.Message);
                     }
                 }
@@ -1525,7 +1562,7 @@ public static class Accessor
         DynamicMethod dynMethod = new DynamicMethod("Invoke" + method.Name, attributes, convention, delegateReturnType, parameterTypes, instance.IsInterface ? typeof(Accessor) : instance, true);
         bool logIl = LogILTraceMessages;
         if (logIl)
-            Logger.LogDebug(source, $"IL: Generating instance caller for {method.DeclaringType.FullName}.{method.Name}:");
+            Logger.LogDebug(source, $"IL: Generating instance caller for {instance.FullName}.{method.Name}:");
         dynMethod.DefineParameter(1, ParameterAttributes.None, "this");
 
         for (int i = 0; i < p.Length; ++i)
@@ -1560,12 +1597,12 @@ public static class Accessor
         }
 
         for (int i = 0; i < p.Length; ++i)
-            generator.EmitParameter(source, i + 1, $"Invalid argument type passed to instance caller for {method.DeclaringType.FullName}.{method.Name} at parameter {i.ToString(CultureInfo.InvariantCulture)} ({p[i].Name}). Expected {p[i].ParameterType.FullName}.", false, type: parameterTypes[i + 1], p[i].ParameterType);
+            generator.EmitParameter(source, i + 1, $"Invalid argument type passed to instance caller for {instance.FullName}.{method.Name} at parameter {i.ToString(CultureInfo.InvariantCulture)} ({p[i].Name}). Expected {p[i].ParameterType.FullName}.", false, type: parameterTypes[i + 1], p[i].ParameterType);
 
         OpCode call = shouldCallvirt ? OpCodes.Callvirt : OpCodes.Call;
         generator.Emit(call, method);
         if (logIl)
-            Logger.LogDebug(source, $"IL:  {(shouldCallvirt ? "callvirt" : "call")} <{method.DeclaringType.FullName}.{method.Name}({string.Join(", ", method.GetParameters().Select(x => x.ParameterType.FullName))})>");
+            Logger.LogDebug(source, $"IL:  {(shouldCallvirt ? "callvirt" : "call")} <{instance.FullName}.{method.Name}({string.Join(", ", method.GetParameters().Select(x => x.ParameterType.FullName))})>");
         if (method.ReturnType != typeof(void) && delegateReturnType == typeof(void))
         {
             generator.Emit(OpCodes.Pop);
@@ -1617,16 +1654,16 @@ public static class Accessor
         {
             Delegate dynamicDelegate = dynMethod.CreateDelegate(delegateType);
             if (LogDebugMessages || logIl)
-                Logger.LogDebug(source, $"Created dynamic method instance caller for {method.DeclaringType.Name}.{method.Name}.");
+                Logger.LogDebug(source, $"Created dynamic method instance caller for {instance.FullName}.{method.Name}.");
             return dynamicDelegate;
         }
         catch (Exception ex)
         {
             if (throwOnError)
-                throw new Exception($"Unable to create instance caller for {method.Name}.", ex);
+                throw new Exception($"Unable to create instance caller for {instance.FullName}.{method.Name}.", ex);
 
             if (LogErrorMessages)
-                Logger.LogError(source, ex, $"Unable to create instance caller for {method.Name}.");
+                Logger.LogError(source, ex, $"Unable to create instance caller for {instance.FullName}.{method.Name}.");
             return null;
         }
     }
@@ -1666,7 +1703,7 @@ public static class Accessor
                     throw new Exception($"Unable to find matching static method: {typeof(TDeclaringType).FullName}.{methodName}.");
 
                 if (LogErrorMessages)
-                    Logger.LogError("Accessor.GenerateStaticCaller", null, $"Unable to find matching static method: {typeof(TDeclaringType).Name}.{methodName}.");
+                    Logger.LogError("Accessor.GenerateStaticCaller", null, $"Unable to find matching static method: {typeof(TDeclaringType).FullName}.{methodName}.");
                 return null;
             }
         }
@@ -1712,7 +1749,7 @@ public static class Accessor
                     throw new Exception($"Unable to find matching static method: {typeof(TDeclaringType).FullName}.{methodName}.");
 
                 if (LogErrorMessages)
-                    Logger.LogError("Accessor.GenerateStaticCaller", null, $"Unable to find matching static method: {typeof(TDeclaringType).Name}.{methodName}.");
+                    Logger.LogError("Accessor.GenerateStaticCaller", null, $"Unable to find matching static method: {typeof(TDeclaringType).FullName}.{methodName}.");
                 return null;
             }
         }
@@ -1793,9 +1830,9 @@ public static class Accessor
         if (method == null || !method.IsStatic)
         {
             if (throwOnError)
-                throw new Exception($"Unable to find static method for delegate: {delegateType.Name}.");
+                throw new Exception($"Unable to find static method for delegate: {delegateType.FullName}.");
             if (LogErrorMessages)
-                Logger.LogError(source, null, $"Unable to find static method for delegate: {delegateType.Name}.");
+                Logger.LogError(source, null, $"Unable to find static method for delegate: {delegateType.FullName}.");
             return null;
         }
 
@@ -1808,10 +1845,10 @@ public static class Accessor
         if (p.Length != delegateParameters.Length)
         {
             if (throwOnError)
-                throw new Exception("Unable to create static caller for " + (method.DeclaringType?.Name ?? "<unknown-type>") + "." + (method.Name ?? "<unknown-name>") + $": incompatable delegate type: {delegateType.Name}.");
+                throw new Exception("Unable to create static caller for " + (method.DeclaringType?.FullName ?? "<unknown-type>") + "." + (method.Name ?? "<unknown-name>") + $": incompatable delegate type: {delegateType.FullName}.");
 
             if (LogErrorMessages)
-                Logger.LogError(source, null, "Unable to create static caller for " + (method.DeclaringType?.Name ?? "<unknown-type>") + "." + (method.Name ?? "<unknown-name>") + $": incompatable delegate type: {delegateType.Name}.");
+                Logger.LogError(source, null, "Unable to create static caller for " + (method.DeclaringType?.FullName ?? "<unknown-type>") + "." + (method.Name ?? "<unknown-name>") + $": incompatable delegate type: {delegateType.FullName}.");
             return null;
         }
 
@@ -1833,14 +1870,14 @@ public static class Accessor
                 {
                     Delegate basicDelegateCaller = method.CreateDelegate(delegateType);
                     if (LogDebugMessages || LogILTraceMessages)
-                        Logger.LogDebug(source, $"Created basic delegate binding static caller for {method.DeclaringType?.Name ?? "<unknown-type>"}.{method.Name}.");
+                        Logger.LogDebug(source, $"Created basic delegate binding static caller for {method.DeclaringType?.FullName ?? "<unknown-type>"}.{method.Name}.");
                     return basicDelegateCaller;
                 }
                 catch (Exception ex)
                 {
                     if (LogDebugMessages || LogILTraceMessages)
                     {
-                        Logger.LogDebug(source, $"Unable to create basic delegate binding static caller for {method.DeclaringType?.Name ?? "<unknown-type>"}.{method.Name}.");
+                        Logger.LogDebug(source, $"Unable to create basic delegate binding static caller for {method.DeclaringType?.FullName ?? "<unknown-type>"}.{method.Name}.");
                         Logger.LogDebug(source, ex.GetType() + " - " + ex.Message);
                     }
                 }

--- a/ReflectionTools/Accessor.cs
+++ b/ReflectionTools/Accessor.cs
@@ -75,7 +75,8 @@ public static class Accessor
             if (!ReferenceEquals(old, value) && old is IDisposable disp)
                 disp.Dispose();
 
-            value?.LogDebug("Accessor.Logger", $"Logger updated: {value.GetType().FullName}.");
+            if (LogInfoMessages)
+                value?.LogInfo("Accessor.Logger", $"Logger updated: {value.GetType().FullName}.");
         }
     }
 
@@ -191,12 +192,11 @@ public static class Accessor
                 {
                     Logger.LogDebug(source, $"IL:  isinst <{field.FieldType.FullName}>");
                     Logger.LogDebug(source, "IL:  dup");
-                    Logger.LogDebug(source, "IL:  brtrue <lbl_0>");
+                    Logger.LogDebug(source, "IL:  brtrue.s <lbl_0>");
                     Logger.LogDebug(source, "IL:  pop");
                     Logger.LogDebug(source, "IL:  ldarg.1");
                     Logger.LogDebug(source, "IL:  dup");
-                    Logger.LogDebug(source, "IL:  ldnull");
-                    Logger.LogDebug(source, "IL:  beq.s <lbl_0>");
+                    Logger.LogDebug(source, "IL:  brfalse.s <lbl_0>");
                     Logger.LogDebug(source, "IL:  pop");
                     Logger.LogDebug(source, "IL:  pop");
                     if (CastExCtor != null)
@@ -397,9 +397,8 @@ public static class Accessor
                     Logger.LogDebug(source, "IL:  brtrue.s <lbl_0>");
                     if (!isValueType)
                         Logger.LogDebug(source, "IL:  pop");
-                    Logger.LogDebug(source, "IL:  ldnull");
                     Logger.LogDebug(source, "IL:  ldarg.0");
-                    Logger.LogDebug(source, "IL:  beq.s <lbl_1>");
+                    Logger.LogDebug(source, "IL:  brfalse.s <lbl_1>");
                     if (CastExCtor != null)
                         Logger.LogDebug(source, $"IL:  ldstr \"{castError}\"");
                     Logger.LogDebug(source, $"IL:  newobj <{(CastExCtor?.DeclaringType ?? NreExCtor!.DeclaringType!).FullName}(System.String)>");
@@ -473,12 +472,11 @@ public static class Accessor
                     {
                         Logger.LogDebug(source, $"IL:  isinst <{field.FieldType.FullName}>");
                         Logger.LogDebug(source, "IL:  dup");
-                        Logger.LogDebug(source, $"IL:  brtrue <lbl_{(lbl1Exists ? "2" : "1")}>");
+                        Logger.LogDebug(source, $"IL:  brtrue.s <lbl_{(lbl1Exists ? "2" : "1")}>");
                         Logger.LogDebug(source, "IL:  pop");
                         Logger.LogDebug(source, "IL:  ldarg.1");
                         Logger.LogDebug(source, "IL:  dup");
-                        Logger.LogDebug(source, "IL:  ldnull");
-                        Logger.LogDebug(source, $"IL:  beq.s <lbl_{(lbl1Exists ? "2" : "1")}>");
+                        Logger.LogDebug(source, $"IL:  brfalse.s <lbl_{(lbl1Exists ? "2" : "1")}>");
                         Logger.LogDebug(source, "IL:  pop");
                         Logger.LogDebug(source, "IL:  pop");
                         if (CastExCtor != null)
@@ -492,7 +490,7 @@ public static class Accessor
                 {
                     il.MarkLabel(typeLbl.Value);
                     if (logIl)
-                        Logger.LogDebug(source, $"IL: lbl_{(lbl1Exists ? "3" : "2")}:");
+                        Logger.LogDebug(source, $"IL: lbl_{(lbl1Exists ? "2" : "1")}:");
                 }
 
                 il.Emit(OpCodes.Stobj, field.FieldType);
@@ -538,12 +536,11 @@ public static class Accessor
                     {
                         Logger.LogDebug(source, $"IL:  isinst <{field.FieldType.FullName}>");
                         Logger.LogDebug(source, "IL:  dup");
-                        Logger.LogDebug(source, $"IL:  brtrue <lbl_{(lbl1Exists ? "2" : "1")}>");
+                        Logger.LogDebug(source, $"IL:  brtrue.s <lbl_{(lbl1Exists ? "2" : "1")}>");
                         Logger.LogDebug(source, "IL:  pop");
                         Logger.LogDebug(source, "IL:  ldarg.1");
                         Logger.LogDebug(source, "IL:  dup");
-                        Logger.LogDebug(source, "IL:  ldnull");
-                        Logger.LogDebug(source, $"IL:  beq.s <lbl_{(lbl1Exists ? "2" : "1")}>");
+                        Logger.LogDebug(source, $"IL:  brfalse.s <lbl_{(lbl1Exists ? "2" : "1")}>");
                         Logger.LogDebug(source, "IL:  pop");
                         Logger.LogDebug(source, "IL:  pop");
                         if (CastExCtor != null)
@@ -654,9 +651,8 @@ public static class Accessor
                     Logger.LogDebug(source, "IL:  dup");
                     Logger.LogDebug(source, "IL:  brtrue.s <lbl_0>");
                     Logger.LogDebug(source, "IL:  pop");
-                    Logger.LogDebug(source, "IL:  ldnull");
                     Logger.LogDebug(source, "IL:  ldarg.0");
-                    Logger.LogDebug(source, "IL:  beq.s <lbl_1>");
+                    Logger.LogDebug(source, "IL:  brfalse.s <lbl_1>");
                     if (CastExCtor != null)
                         Logger.LogDebug(source, $"IL:  ldstr \"{castError}\"");
                     Logger.LogDebug(source, $"IL:  newobj <{(CastExCtor?.DeclaringType ?? NreExCtor!.DeclaringType!).FullName}(System.String)>");
@@ -1004,12 +1000,11 @@ public static class Accessor
                 {
                     Logger.LogDebug(source, $"IL:  isinst <{field.FieldType.FullName}>");
                     Logger.LogDebug(source, "IL:  dup");
-                    Logger.LogDebug(source, "IL:  brtrue <lbl_0>");
+                    Logger.LogDebug(source, "IL:  brtrue.s <lbl_0>");
                     Logger.LogDebug(source, "IL:  pop");
                     Logger.LogDebug(source, "IL:  ldarg.0");
                     Logger.LogDebug(source, "IL:  dup");
-                    Logger.LogDebug(source, "IL:  ldnull");
-                    Logger.LogDebug(source, "IL:  beq.s <lbl_0>");
+                    Logger.LogDebug(source, "IL:  brfalse.s <lbl_0>");
                     Logger.LogDebug(source, "IL:  pop");
                     if (CastExCtor != null)
                         Logger.LogDebug(source, $"IL:  ldstr \"{errMsg}\"");
@@ -1454,7 +1449,7 @@ public static class Accessor
         bool isInstanceForValueType = method is { DeclaringType.IsValueType: true };
         shouldCallvirt |= !instance.IsValueType;
 
-        // for some reasons invoking a delegate with zero parameters and a null instance does not throw an exception.
+        // for some reason invoking a delegate with zero parameters and a null instance does not throw an exception.
         // Adding parameters changes this behavior.
         if (!isInstanceForValueType && p.Length == 0 && !allowUnsafeTypeBinding)
             needsDynamicMethod = true;
@@ -2003,10 +1998,10 @@ public static class Accessor
         catch (Exception ex)
         {
             if (throwOnError)
-                throw new Exception($"Unable to create static caller for {method}.", ex);
+                throw new Exception($"Unable to create static caller for {method.DeclaringType?.FullName ?? "<unknown-type>"}.{method.Name}.", ex);
 
             if (LogErrorMessages)
-                Logger.LogError(source, ex, $"Unable to create static caller for {method}.");
+                Logger.LogError(source, ex, $"Unable to create static caller for {method.DeclaringType?.FullName ?? "<unknown-type>"}.{method.Name}.");
             return null;
         }
     }
@@ -2077,7 +2072,24 @@ public static class Accessor
     /// Checks <paramref name="method"/> for the <see langword="extern"/> flag.
     /// </summary>
     [Pure]
-    public static bool IsExtern(this MethodBase method) => (method.Attributes & MethodAttributes.PinvokeImpl) != 0;
+    public static bool IsExtern(this MethodBase method)
+    {
+        if ((method.Attributes & MethodAttributes.PinvokeImpl) != 0)
+            return true;
+
+        if (method.IsAbstract || method.IsVirtual || method.DeclaringType is { IsInterface: true })
+            return false;
+
+        try
+        {
+            method.GetMethodBody();
+            return false;
+        }
+        catch
+        {
+            return true;
+        }
+    }
 
     /// <summary>
     /// Checks <paramref name="field"/> for the <see langword="extern"/> flag.
@@ -2099,19 +2111,7 @@ public static class Accessor
                 return false;
         }
 
-        if ((method.Attributes & MethodAttributes.PinvokeImpl) != 0)
-            return true;
-        if (method.IsAbstract || method.IsVirtual || method.DeclaringType!.IsInterface)
-            return false;
-        try
-        {
-            method.GetMethodBody();
-            return false;
-        }
-        catch (BadImageFormatException)
-        {
-            return true;
-        }
+        return method.IsExtern();
     }
 
     /// <summary>
@@ -2878,12 +2878,14 @@ public static class Accessor
     /// Checks if it's possible for a variable of type <paramref name="actualType"/> to have a value of type <paramref name="queriedType"/>. 
     /// </summary>
     /// <returns><see langword="true"/> if <paramref name="actualType"/> is assignable from <paramref name="queriedType"/> or if <paramref name="queriedType"/> is assignable from <paramref name="actualType"/>.</returns>
+    [Pure]
     public static bool CouldBeAssignedTo(this Type actualType, Type queriedType) => actualType.IsAssignableFrom(queriedType) || queriedType.IsAssignableFrom(actualType);
 
     /// <summary>
     /// Checks if it's possible for a variable of type <paramref name="actualType"/> to have a value of type <typeparamref name="T"/>. 
     /// </summary>
     /// <returns><see langword="true"/> if <paramref name="actualType"/> is assignable from <typeparamref name="T"/> or if <typeparamref name="T"/> is assignable from <paramref name="actualType"/>.</returns>
+    [Pure]
     public static bool CouldBeAssignedTo<T>(this Type actualType) => actualType.CouldBeAssignedTo(typeof(T));
     private static class DelegateInfo<TDelegate> where TDelegate : Delegate
     {

--- a/ReflectionTools/EmitUtility.cs
+++ b/ReflectionTools/EmitUtility.cs
@@ -484,7 +484,7 @@ public static class EmitUtility
     /// <summary>
     /// Transfers blocks that would be on the last instruction of a block to the target instruction.
     /// </summary>
-    public static void TransferEndingInstructionNeeds(CodeInstruction originalEnd, CodeInstruction newEnd)
+    public static void TransferEndingInstructionNeeds(this CodeInstruction originalEnd, CodeInstruction newEnd)
     {
         newEnd.blocks.AddRange(originalEnd.blocks.Where(x => x.blockType.IsEndBlockType()));
         originalEnd.blocks.RemoveAll(x => x.blockType.IsEndBlockType());
@@ -493,7 +493,7 @@ public static class EmitUtility
     /// <summary>
     /// Transfers all labels and blocks that would be on the first instruction of a block to the target instruction.
     /// </summary>
-    public static void TransferStartingInstructionNeeds(CodeInstruction originalStart, CodeInstruction newStart)
+    public static void TransferStartingInstructionNeeds(this CodeInstruction originalStart, CodeInstruction newStart)
     {
         newStart.labels.AddRange(originalStart.labels);
         originalStart.labels.Clear();

--- a/ReflectionTools/EmitUtility.cs
+++ b/ReflectionTools/EmitUtility.cs
@@ -484,7 +484,25 @@ public static class EmitUtility
     /// <summary>
     /// Transfers blocks that would be on the last instruction of a block to the target instruction.
     /// </summary>
-    public static void TransferEndingInstructionNeeds(this CodeInstruction originalEnd, CodeInstruction newEnd)
+    public static CodeInstruction WithEndingInstructionNeeds(this CodeInstruction instruction, CodeInstruction other)
+    {
+        TransferEndingInstructionNeeds(instruction, other);
+        return instruction;
+    }
+
+    /// <summary>
+    /// Transfers all labels and blocks that would be on the first instruction of a block to the target instruction.
+    /// </summary>
+    public static CodeInstruction WithStartingInstructionNeeds(this CodeInstruction instruction, CodeInstruction other)
+    {
+        TransferStartingInstructionNeeds(instruction, other);
+        return instruction;
+    }
+
+    /// <summary>
+    /// Transfers blocks that would be on the last instruction of a block to the target instruction.
+    /// </summary>
+    public static void TransferEndingInstructionNeeds(CodeInstruction originalEnd, CodeInstruction newEnd)
     {
         newEnd.blocks.AddRange(originalEnd.blocks.Where(x => x.blockType.IsEndBlockType()));
         originalEnd.blocks.RemoveAll(x => x.blockType.IsEndBlockType());
@@ -493,7 +511,7 @@ public static class EmitUtility
     /// <summary>
     /// Transfers all labels and blocks that would be on the first instruction of a block to the target instruction.
     /// </summary>
-    public static void TransferStartingInstructionNeeds(this CodeInstruction originalStart, CodeInstruction newStart)
+    public static void TransferStartingInstructionNeeds(CodeInstruction originalStart, CodeInstruction newStart)
     {
         newStart.labels.AddRange(originalStart.labels);
         originalStart.labels.Clear();
@@ -701,8 +719,7 @@ public static class EmitUtility
             else
                 generator.Emit(code);
             generator.Emit(OpCodes.Dup);
-            generator.Emit(OpCodes.Ldnull);
-            generator.Emit(OpCodes.Beq_S, lbl);
+            generator.Emit(OpCodes.Brfalse, lbl);
             generator.Emit(OpCodes.Pop);
             castErrorMessage ??= $"Invalid type passed to parameter {index.ToString(CultureInfo.InvariantCulture)}.";
             if (Accessor.CastExCtor != null)
@@ -727,8 +744,7 @@ public static class EmitUtility
                     _ => $"IL:  ldarg <{index.ToString(CultureInfo.InvariantCulture)}"
                 });
                 Accessor.Logger.LogDebug(logSource, "IL:  dup");
-                Accessor.Logger.LogDebug(logSource, "IL:  ldnull");
-                Accessor.Logger.LogDebug(logSource, $"IL:  beq.s <lbl_{lblId}>");
+                Accessor.Logger.LogDebug(logSource, $"IL:  brfalse <lbl_{lblId}>");
                 Accessor.Logger.LogDebug(logSource, "IL:  pop");
                 if (Accessor.CastExCtor != null)
                     Accessor.Logger.LogDebug(logSource, $"IL:  ldstr \"{castErrorMessage}\"");

--- a/ReflectionTools/IoC/LoggerFactoryExtensions.cs
+++ b/ReflectionTools/IoC/LoggerFactoryExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿#if NET461_OR_GREATER || !NETFRAMEWORK
+using Microsoft.Extensions.Logging;
 
 namespace DanielWillett.ReflectionTools.IoC;
 
@@ -18,3 +19,4 @@ public static class LoggerFactoryExtensions
         return new ReflectionToolsLoggerProxy(loggerFactory, disposeFactoryOnDispose);
     }
 }
+#endif

--- a/ReflectionTools/Loggers.cs
+++ b/ReflectionTools/Loggers.cs
@@ -1,8 +1,11 @@
-﻿using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+
+#if NET461_OR_GREATER || !NETFRAMEWORK
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+#endif
 
 namespace DanielWillett.ReflectionTools;
 
@@ -36,6 +39,7 @@ public interface IReflectionToolsLogger
     void LogError(string source, Exception? ex, string? message);
 }
 
+#if NET461_OR_GREATER || !NETFRAMEWORK
 /// <summary>
 /// Implement a <see cref="ILogger"/> through <see cref="IReflectionToolsLogger"/>.
 /// </summary>
@@ -119,6 +123,7 @@ public class ReflectionToolsLoggerProxy : IReflectionToolsLogger, IDisposable
             LoggerFactory.Dispose();
     }
 }
+#endif
 
 /// <summary>
 /// Logs messages to the <see cref="Console"/>.

--- a/ReflectionTools/ReflectionTools.csproj
+++ b/ReflectionTools/ReflectionTools.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net481;net60;net70;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net461;net481;net471;net45;net6.0;net5.0;net7.0;netstandard2.1;netstandard2.0;netcoreapp3.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
 
@@ -10,7 +10,7 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <PackageId>DanielWillett.ReflectionTools</PackageId>
     <Title>Reflection Tools</Title>
-    <Version>1.1.0</Version>
+    <Version>2.0.0</Version>
     <PackageReleaseNotes></PackageReleaseNotes>
     <Authors>Daniel Willett</Authors>
     <Product>DanielWillett.ReflectionTools</Product>
@@ -36,8 +36,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Lib.Harmony" Version="[2.2.2,)" Condition="'$(TargetFramework)' != 'netstandard2.1'" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />
+    <PackageReference Include="Lib.Harmony" Version="[2.2.2,)" Condition="'$(TargetFramework)' != 'netstandard2.1' And '$(TargetFramework)' != 'netstandard2.0'" />
+    <PackageReference Include="System.Reflection.Emit" Version="[4.6.0,)" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="[4.6.0,)" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="[4.6.0,)" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" Condition="'$(TargetFramework)' != 'net45'" />
   </ItemGroup>
 
 </Project>

--- a/ReflectionTools/ReflectionTools.csproj.DotSettings
+++ b/ReflectionTools/ReflectionTools.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=deprecated/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
Many fixes, including:
* Fixed spelling mistake in `EmitUtility` (was `EmitUtilitiy`).
* Fixed some minor bugs with edge cases in the accessor-generating methods (mostly when casting between `object` and value types in uncommon situations).
* Type checking when you pass a different object in when the actual type is a reference type. Turn this off by setting `allowUnsafeTypeBinding = true`.
* Added extensive unit tests for those methods.
* Added more logging so you can see the IL generated by those methods if desired (`Accessor.LogILTraceMessages = true;`).
